### PR TITLE
feat: add build info footer and favicon

### DIFF
--- a/version.go
+++ b/version.go
@@ -1,0 +1,8 @@
+package main
+
+// Build-time variables injected via ldflags
+var (
+	version = "unknown"
+	commit  = "unset"
+	date    = "unset"
+)

--- a/web.go
+++ b/web.go
@@ -20,8 +20,15 @@ type webServer struct {
 	templates *template.Template
 }
 
+type buildInfo struct {
+	Version string
+	Commit  string
+	Date    string
+}
+
 type indexData struct {
 	Kinds []string
+	Build buildInfo
 }
 
 type resourceData struct {
@@ -71,8 +78,13 @@ func (w *webServer) handleIndex(rw http.ResponseWriter, r *http.Request) {
 	}
 	sort.Strings(kinds)
 
+	bi := buildInfo{Version: version, Commit: commit, Date: date}
+	if len(bi.Commit) > 7 {
+		bi.Commit = bi.Commit[:7]
+	}
+
 	rw.Header().Set("Content-Type", "text/html; charset=utf-8")
-	if err := w.templates.ExecuteTemplate(rw, "index.html", indexData{Kinds: kinds}); err != nil {
+	if err := w.templates.ExecuteTemplate(rw, "index.html", indexData{Kinds: kinds, Build: bi}); err != nil {
 		slog.Error("failed to render index", "error", err)
 		http.Error(rw, "Internal Server Error", http.StatusInternalServerError)
 	}

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Machinery - Resource Dashboard</title>
+    <link rel="icon" type="image/png" href="https://raw.githubusercontent.com/stuttgart-things/docs/main/hugo/sthings-argo.png">
     <script src="https://unpkg.com/htmx.org@2.0.4"></script>
     <style>
         :root {
@@ -216,6 +217,21 @@
             color: var(--text);
         }
         .detail-refresh { display: none; }
+        footer {
+            margin-top: 2rem;
+            padding-top: 1rem;
+            border-top: 1px solid var(--border);
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            font-size: 0.75rem;
+            color: var(--text-muted);
+        }
+        footer .build-info {
+            display: flex;
+            gap: 1.5rem;
+        }
+        footer .build-info span { font-family: "SF Mono", "Cascadia Code", "Fira Code", monospace; }
     </style>
 </head>
 <body>
@@ -249,6 +265,15 @@
              hx-trigger="load, every 5s"
              hx-indicator="#spinner">
         </div>
+
+        <footer>
+            <span>stuttgart-things/machinery</span>
+            <div class="build-info">
+                <span>{{.Build.Version}}</span>
+                <span>{{.Build.Commit}}</span>
+                <span>{{.Build.Date}}</span>
+            </div>
+        </footer>
     </div>
 
     <script>


### PR DESCRIPTION
Closes #43
Closes #44

## Summary
- Add `version.go` with ldflags build-time variables (version, commit, date)
- Footer showing version, truncated commit hash (7 chars), and build date
- Favicon using stuttgart-things branding image
- Defaults to "unknown"/"unset" for local dev builds

## Build-time injection
```bash
go build -ldflags "-X main.version=v1.2.0 -X main.commit=$(git rev-parse --short HEAD) -X main.date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" .
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)