### PR TITLE
fix: add docs directory for pages deployment

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,5 @@
+# Machinery
+
+gRPC + HTMX service for monitoring Crossplane-managed Kubernetes custom resources.
+
+See [GitHub](https://github.com/stuttgart-things/machinery) for documentation.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,5 @@
+---
+site_name: machinery
+site_url: https://stuttgart-things.github.io/machinery
+repo_name: stuttgart-things/machinery
+repo_url: https://github.com/stuttgart-things/machinery


### PR DESCRIPTION
## Summary
The pages workflow writes `docs/releases.md` from `CHANGELOG.md` but the `docs/` directory didn't exist.

- Add `docs/index.md` 
- Add `mkdocs.yml` config

🤖 Generated with [Claude Code](https://claude.com/claude-code)