### PR TITLE
feat: rework README and align footer with clusterbook branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # stuttgart-things/machinery
 
-gRPC service for querying Stuttgart-Things Kubernetes custom resources. Watches any Crossplane-managed resource with configurable status field extraction. Returns resource status, readiness, and connection details across namespaces. Includes an HTMX web frontend for browsing resources.
+Kubernetes resource dashboard and gRPC service for monitoring [Crossplane](https://www.crossplane.io/)-managed custom resources. Watches any CR with configurable status/info field extraction and exposes results via gRPC API and an HTMX web frontend.
 
 ## Architecture
 
@@ -10,31 +10,155 @@ Browser (HTMX) ──> HTTP :8080 ──┐
 Client (gRPC)  ──> gRPC :50051 ─┘        (dynamic client)
 ```
 
-## Quick Start
+**Endpoints:**
 
-### Server
+| Protocol | Port | Paths |
+|----------|------|-------|
+| gRPC | 50051 | `ResourceService.GetResources`, `ResourceService.GetResourceDetail` |
+| HTTP | 8080 | `/` (dashboard), `/resources` (table), `/detail` (detail view), `/health` |
 
-```bash
-export KUBECONFIG=~/.kube/config
-go run main.go
-```
+## Web Frontend
 
-### Client
+HTMX-based dashboard at `http://localhost:8080`:
 
-```bash
-export CLUSTERBOOK_SERVER=localhost:50051
-export SECURE_CONNECTION=false
-go run client/client.go
+- Auto-refreshing resource table (5s interval)
+- Filter by resource kind
+- Clickable rows for detail view with info fields
+- Ready/Not Ready status badges
+- Build info footer (version, commit, date)
+- Dark theme
+
+## gRPC API
+
+```protobuf
+service ResourceService {
+  rpc GetResources(ResourceRequest) returns (ResourceListResponse);
+  rpc GetResourceDetail(ResourceDetailRequest) returns (ResourceStatus);
+}
+
+message ResourceRequest {
+  int32 count = 1;    // -1 for all, max 1000
+  string kind = 2;    // e.g. "VsphereVM", comma-separated, or "*" for all
+}
+
+message ResourceDetailRequest {
+  string kind = 1;
+  string name = 2;
+  string namespace = 3;
+}
+
+message ResourceStatus {
+  string name = 1;
+  string kind = 2;
+  bool ready = 3;
+  string status_message = 4;
+  string connection_details = 5;
+  string namespace = 6;
+  map<string, string> info_fields = 7;
+}
 ```
 
 ## Configuration
+
+Resource types are configurable via JSON. Set `MACHINERY_CONFIG` to load a custom config file.
 
 ### Environment Variables
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `KUBECONFIG` | Path to kubeconfig file | required |
+| `KUBECONFIG` | Path to kubeconfig file | in-cluster config |
 | `MACHINERY_CONFIG` | Path to JSON config file | built-in defaults |
+
+### Config File
+
+Each resource kind supports:
+
+- **`group`/`version`/`resource`** — GVR for the Kubernetes custom resource
+- **`connectionField`** — dot-separated path to extract a primary connection value (e.g., `status.share.ip`)
+- **`statusFields`** — dot-separated paths displayed as status indicators
+- **`infoFields`** — labeled fields for the detail view, each with a `label` and `path`
+
+Field extraction supports string, bool, and int64 types automatically.
+
+```json
+{
+  "port": 50051,
+  "httpPort": 8080,
+  "resources": {
+    "VsphereVM": {
+      "group": "resources.stuttgart-things.com",
+      "version": "v1alpha1",
+      "resource": "vspherevms",
+      "connectionField": "status.share.ip",
+      "statusFields": ["status.share.ip"],
+      "infoFields": [
+        {"label": "Datacenter", "path": "spec.vm.datacenter"},
+        {"label": "Template", "path": "spec.vm.template"},
+        {"label": "Network", "path": "spec.vm.network"}
+      ]
+    }
+  }
+}
+```
+
+## Deployment
+
+### KCL Manifests
+
+Machinery uses [KCL](https://www.kcl-lang.io/) for Kubernetes manifests (no Helm). The KCL manifests are also the source for OCI kustomize artifacts pushed by the CI release workflow to `ghcr.io/stuttgart-things/machinery-kustomize`.
+
+```bash
+# Render manifests
+kcl run kcl/main.k -Y tests/kcl-deploy-profile.yaml
+
+# Apply directly
+kcl run kcl/main.k -Y tests/kcl-deploy-profile.yaml | kubectl apply -f -
+```
+
+Features: gRPC/HTTP health probes, hardened security context (non-root, read-only rootfs, drop all capabilities), pod anti-affinity, optional kubeconfig secret mount, Gateway API HTTPRoute.
+
+See [`kcl/README.md`](kcl/README.md) for all configuration options and manifest structure.
+
+### Flux CD
+
+Machinery can be deployed via [Flux CD](https://fluxcd.io/) using OCI-based Kustomizations.
+
+| Resource | Description |
+|----------|-------------|
+| [Flux app manifests](https://github.com/stuttgart-things/flux/tree/main/apps/machinery) | Upstream Flux Kustomization, OCIRepository, HTTPRoute, and Namespace |
+| [Cluster config example](https://github.com/stuttgart-things/stuttgart-things/blob/main/clusters/labul/vsphere/cd-mgmt-1/apps/machinery.yaml) | Per-cluster Flux Kustomization with `postBuild` variable substitution and config injection patches |
+
+The upstream app manifests define the base deployment, while per-cluster configs customize version, hostname, gateway, and resource configuration via `postBuild.substitute` and strategic merge patches.
+
+### Container Image
+
+Built with [ko](https://ko.build/) on `cgr.dev/chainguard/static:latest` (distroless). Version, commit, and date are injected via ldflags at build time.
+
+```
+ghcr.io/stuttgart-things/machinery:<tag>
+```
+
+## Development
+
+### Prerequisites
+
+- Go 1.25+
+- [Task](https://taskfile.dev/) (optional, for task runner)
+- [KCL](https://www.kcl-lang.io/) (for rendering deployment manifests)
+- [protoc](https://grpc.io/docs/protoc-installation/) + Go plugins (for proto generation)
+
+### Run Locally
+
+```bash
+# Server
+export KUBECONFIG=~/.kube/config
+go run main.go
+
+# Client
+export CLUSTERBOOK_SERVER=localhost:50051
+export SECURE_CONNECTION=false
+go run client/client.go
+```
 
 ### Client Environment Variables
 
@@ -45,89 +169,34 @@ go run client/client.go
 | `TLS_CA_CERT` | Path to CA certificate | system CA pool |
 | `TLS_SKIP_VERIFY` | Skip cert verification (dev only) | `false` |
 
-### Config File
-
-Resource types are configurable via JSON. Set `MACHINERY_CONFIG` to load a custom config. Each resource kind supports:
-
-- **`group`/`version`/`resource`** — the GVR for the Kubernetes custom resource
-- **`connectionField`** — dot-separated path to extract a primary connection value (e.g., `status.vm.name`)
-- **`statusFields`** — list of dot-separated paths displayed as `label=value` pairs
-
-Field extraction supports string, bool, and int64 types automatically.
-
-```json
-{
-  "port": 50051,
-  "httpPort": 8080,
-  "resources": {
-    "HarvesterVM": {
-      "group": "resources.stuttgart-things.com",
-      "version": "v1alpha1",
-      "resource": "harvestervms",
-      "connectionField": "status.vm.name",
-      "statusFields": ["status.volume.ready", "status.cloudInit.ready", "status.vm.ready"]
-    },
-    "StoragePlatform": {
-      "group": "resources.stuttgart-things.com",
-      "version": "v1alpha1",
-      "resource": "storageplatforms",
-      "statusFields": ["status.installed", "status.observedVersion"]
-    }
-  }
-}
-```
-
-## Default Resource Types
-
-| Kind | API Group | Resource | Connection Field |
-|------|-----------|----------|-----------------|
-| HarvesterVM | resources.stuttgart-things.com/v1alpha1 | harvestervms | `status.vm.name` |
-| StoragePlatform | resources.stuttgart-things.com/v1alpha1 | storageplatforms | — |
-| NetworkIntegration | resources.stuttgart-things.com/v1alpha1 | networkintegrations | — |
-
-## gRPC API
-
-```protobuf
-service ResourceService {
-  rpc GetResources(ResourceRequest) returns (ResourceListResponse);
-}
-
-message ResourceRequest {
-  string kind = 1;   // e.g. "HarvesterVM", comma-separated, or "*" for all
-  int32 count = 2;   // -1 for all, max 1000
-}
-```
-
-## Web Frontend
-
-HTMX-based dashboard available at `http://localhost:8080`. Features:
-- Auto-refreshing resource table (10s interval)
-- Filter by resource kind
-- Ready/Not Ready status badges
-- Dark theme
-
-## Deployment
-
-KCL-based Kubernetes deployment (no Helm):
+### Tests
 
 ```bash
-kcl run kcl/main.k -Y tests/kcl-deploy-profile.yaml
-```
-
-See `kcl/` directory for all manifests. Features: gRPC health probes, hardened security context, optional kubeconfig secret mount.
-
-## Development
-
-```bash
-# Run tests
 go test -v -race ./...
+```
 
-# Build
-go build -o machinery .
+### Proto Generation
 
-# Generate proto
+```bash
 task proto
 ```
+
+### Task Runner
+
+```bash
+task --list   # list available tasks
+task server   # run server
+task client   # run client
+```
+
+## Links
+
+| Resource | URL |
+|----------|-----|
+| Documentation (GitHub Pages) | <https://stuttgart-things.github.io/machinery> |
+| Container Image | `ghcr.io/stuttgart-things/machinery` |
+| OCI Kustomize Artifacts | `ghcr.io/stuttgart-things/machinery-kustomize` |
+| Changelog | [CHANGELOG.md](CHANGELOG.md) |
 
 ## License
 

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -219,19 +219,21 @@
         .detail-refresh { display: none; }
         footer {
             margin-top: 2rem;
-            padding-top: 1rem;
+            padding: 1rem 0;
             border-top: 1px solid var(--border);
             display: flex;
-            justify-content: space-between;
-            align-items: center;
+            justify-content: center;
+            gap: 2rem;
             font-size: 0.75rem;
             color: var(--text-muted);
         }
-        footer .build-info {
+        .footer-item {
             display: flex;
-            gap: 1.5rem;
+            align-items: center;
+            gap: 0.35rem;
         }
-        footer .build-info span { font-family: "SF Mono", "Cascadia Code", "Fira Code", monospace; }
+        .footer-label { color: var(--text-muted); }
+        .footer-value { color: #94a3b8; font-family: "SF Mono", "Cascadia Code", "Fira Code", monospace; }
     </style>
 </head>
 <body>
@@ -267,12 +269,10 @@
         </div>
 
         <footer>
-            <span>stuttgart-things/machinery</span>
-            <div class="build-info">
-                <span>{{.Build.Version}}</span>
-                <span>{{.Build.Commit}}</span>
-                <span>{{.Build.Date}}</span>
-            </div>
+            <div class="footer-item"><span class="footer-label">version</span> <span class="footer-value">{{.Build.Version}}</span></div>
+            <div class="footer-item"><span class="footer-label">commit</span> <span class="footer-value">{{.Build.Commit}}</span></div>
+            <div class="footer-item"><span class="footer-label">built</span> <span class="footer-value">{{.Build.Date}}</span></div>
+            <div class="footer-item" style="margin-left:auto"><span class="footer-label">a</span> <a href="https://github.com/stuttgart-things" target="_blank" style="color:#818cf8;text-decoration:none">stuttgart-things</a> <span class="footer-label">project</span> <img src="https://raw.githubusercontent.com/stuttgart-things/docs/main/hugo/sthings-logo.png" alt="sthings" style="height:24px;vertical-align:middle"></div>
         </footer>
     </div>
 


### PR DESCRIPTION
## Summary
- Rewrite README with accurate Deployment (KCL, Flux CD links) and Development sections reflecting current codebase
- Update web footer to labeled format (version/commit/built) with stuttgart-things project branding and logo, matching clusterbook style
- Add Links section with GitHub Pages, container image, and OCI kustomize artifact references

## Test plan
- [x] `go test -v -race ./...` passes
- [ ] Verify footer renders correctly in browser
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)