### PR TITLE
feat: add PR-preview CI workflows

### DIFF
--- a/.github/workflows/cleanup-pr-artifacts.yaml
+++ b/.github/workflows/cleanup-pr-artifacts.yaml
@@ -1,0 +1,20 @@
+---
+# When a PR is closed (merged or not), delete the `pr-<number>-*` tags
+# from ghcr for both the runtime image and the kustomize OCI artifact.
+# Keeps ghcr from accumulating per-PR cruft once the preview env is
+# torn down by Argo.
+name: Cleanup PR Artifacts
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+jobs:
+  cleanup:
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-cleanup-pr-artifacts.yaml@main
+    with:
+      runs-on: ubuntu-latest
+      packages: machinery,machinery-kustomize
+      dry-run: false
+    secrets: inherit # pragma: allowlist secret

--- a/.github/workflows/comment-preview-url.yaml
+++ b/.github/workflows/comment-preview-url.yaml
@@ -1,0 +1,20 @@
+---
+# Post a "preview env is at <URL>" comment back on the PR when it opens
+# or is reopened. The hostname pattern and namespace prefix here must
+# match the AppSet in stuttgart-things/argocd
+# (platforms/machinery-pr-preview/appset-machinery-pr-preview.yaml).
+name: Comment Preview URL on PR
+on:
+  pull_request:
+    types: [opened, reopened]
+    branches:
+      - main
+
+jobs:
+  comment:
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-comment-preview-url.yaml@main
+    with:
+      hostname-prefix: machinery-pr
+      hostname-domain: homerun2-dev.sthings-vsphere.labul.sva.de
+      namespace-prefix: machinery-pr
+    secrets: inherit # pragma: allowlist secret

--- a/.github/workflows/push-kustomize-pr.yaml
+++ b/.github/workflows/push-kustomize-pr.yaml
@@ -1,0 +1,28 @@
+---
+# Build + push a per-PR container image and kustomize OCI artifact, both
+# tagged `pr-<number>-<head_sha>`. The pr-preview ApplicationSet in
+# stuttgart-things/argocd (platforms/machinery-pr-preview) consumes these
+# tags via the `apps/machinery/install` parent chart.
+#
+# Tag format matches `.head_sha` exposed by Argo's pullRequest generator,
+# so the AppSet can interpolate it verbatim without massaging the SHA.
+name: Push PR Kustomize OCI
+on:
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  push-kustomize:
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-push-kustomize.yaml@main
+    with:
+      runs-on: ubuntu-latest
+      kcl-source-dir: kcl
+      kcl-profile-file: tests/kcl-deploy-profile.yaml
+      kustomize-oci-repo: ghcr.io/stuttgart-things/machinery-kustomize
+      tag: pr-${{ github.event.number }}-${{ github.event.pull_request.head.sha }}
+    secrets: inherit # pragma: allowlist secret


### PR DESCRIPTION
## Summary

Three thin wrappers around `stuttgart-things/github-workflow-templates`, matching the pattern used by `homerun2-git-pitcher` and the other pitchers:

- **`push-kustomize-pr.yaml`** — builds + pushes image + kustomize OCI as `pr-<n>-<sha>` on PR sync
- **`cleanup-pr-artifacts.yaml`** — deletes the `pr-<n>-*` OCI tags on PR close
- **`comment-preview-url.yaml`** — posts the preview URL on PR open/reopen

Together with [`stuttgart-things/argocd#TBD`](https://github.com/stuttgart-things/argocd/pulls) (`platforms/machinery-pr-preview/`), opening a PR labelled `preview` on this repo spins up an isolated environment at `machinery-pr-<n>.homerun2-dev.sthings-vsphere.labul.sva.de` and tears it down on close.

## Companion PR

- `stuttgart-things/argocd` — `platforms/machinery-pr-preview/` AppSet + bootstrap (link to follow once that PR is opened)

## Still needs (out-of-scope for this PR)

- A `Kustomization` in `stuttgart-things/stuttgart-things` pointing at the new argocd platforms dir
- `machinery-pr-preview: "true"` label on the target cluster's `ClusterbookCluster`

## Test plan

- [ ] After merge, open a throwaway PR with the `preview` label and confirm:
  - [ ] `push-kustomize-pr` publishes `ghcr.io/stuttgart-things/machinery:pr-<n>-<sha>` and `ghcr.io/stuttgart-things/machinery-kustomize:pr-<n>-<sha>`
  - [ ] `comment-preview-url` posts a URL comment on the PR
  - [ ] Closing the PR triggers `cleanup-pr-artifacts` and the OCI tags disappear from ghcr

🤖 Generated with [Claude Code](https://claude.com/claude-code)