### PR TITLE
fix(kcl): mount MACHINERY_CONFIG as a file (closes #52)

### DIFF
--- a/kcl/configmap.k
+++ b/kcl/configmap.k
@@ -1,12 +1,15 @@
 """
-ConfigMap for machinery
+ConfigMaps for machinery
+
+- envConfigMap: scalar env vars consumed via envFrom
+- fileConfigMap: the machinery JSON config, mounted as /etc/machinery/config.json
 """
 
 import labels
 
 config = labels.config
 
-configMap = {
+envConfigMap = {
     apiVersion: "v1"
     kind: "ConfigMap"
     metadata: {
@@ -19,3 +22,16 @@ configMap = {
         **config.extraEnvVars
     }
 }
+
+fileConfigMap = {
+    apiVersion: "v1"
+    kind: "ConfigMap"
+    metadata: {
+        name: "{}-config-file".format(config.name)
+        namespace: config.namespace
+        labels: labels.commonLabels
+    }
+    data: {
+        "config.json": config.configJson
+    }
+} if config.configJson else None

--- a/kcl/deploy.k
+++ b/kcl/deploy.k
@@ -59,12 +59,7 @@ deployment = {
                             if config.configJson:
                                 {
                                     name: "MACHINERY_CONFIG"
-                                    valueFrom: {
-                                        configMapKeyRef: {
-                                            name: "{}-config".format(config.name)
-                                            key: "config.json"
-                                        }
-                                    }
+                                    value: "/etc/machinery/config.json"
                                 }
                         ]
                         envFrom: [
@@ -121,7 +116,13 @@ deployment = {
                                 mountPath: "/etc/kubeconfig"
                                 readOnly: True
                             }
-                        ] if config.kubeconfigSecret else [])
+                        ] if config.kubeconfigSecret else []) + ([
+                            {
+                                name: "config-file"
+                                mountPath: "/etc/machinery"
+                                readOnly: True
+                            }
+                        ] if config.configJson else [])
                     }
                 ]
                 securityContext: {
@@ -145,7 +146,14 @@ deployment = {
                             secretName: config.kubeconfigSecret
                         }
                     }
-                ] if config.kubeconfigSecret else [])
+                ] if config.kubeconfigSecret else []) + ([
+                    {
+                        name: "config-file"
+                        configMap: {
+                            name: "{}-config-file".format(config.name)
+                        }
+                    }
+                ] if config.configJson else [])
                 affinity: {
                     podAntiAffinity: {
                         preferredDuringSchedulingIgnoredDuringExecution: [

--- a/kcl/main.k
+++ b/kcl/main.k
@@ -15,7 +15,8 @@ manifests = [
     m for m in [
         namespace.namespace
         serviceaccount.serviceAccount
-        configmap.configMap
+        configmap.envConfigMap
+        configmap.fileConfigMap
         deploy.deployment
         service.service
         httproute.httproute


### PR DESCRIPTION
## Summary

- Splits the deployment ConfigMap into two: `{name}-config` keeps the env vars (`envFrom`), and a new `{name}-config-file` carries the JSON at key `config.json`.
- `MACHINERY_CONFIG` is now a plain `value: /etc/machinery/config.json` env var; the JSON is mounted there from the new ConfigMap.
- Both the new ConfigMap and the mount/volume are gated on `config.configJson` — when unset, manifests render identically to before.

Closes #52.

## Why

Previously `kcl/deploy.k` wired `MACHINERY_CONFIG` via `configMapKeyRef`, which puts the **contents** of `config.json` into the env var. `main.go` and `config.go:loadConfig` treat the value as a **path** and call `os.ReadFile(...)` on it, so any deployment that actually set `configJson` would crash at startup. The KCL was also referencing a `config.json` key that the ConfigMap never defined, so the wiring was doubly broken.

Aligns with option 1 from #52 (mount as volume — idiomatic for Kubernetes).

## Test plan

- [x] `kcl run` with the default profile (no `configJson`): output unchanged — no extra ConfigMap, no `MACHINERY_CONFIG` env var, no `config-file` volume.
- [x] `kcl run` with `configJson` set: renders second ConfigMap, `MACHINERY_CONFIG=/etc/machinery/config.json`, volume mount at `/etc/machinery`, volume backed by the new ConfigMap.
- [ ] Preview env: pod starts cleanly, machinery logs `loaded config from file path=/etc/machinery/config.json` when `configJson` is set.

## Follow-up (not in this PR)

KCL CLI's `-Y` profile loader auto-coerces `{...}` values into dicts before the schema's `str` type check, so passing raw JSON via `kcl_options.config.configJson` errors with `expect str, got dict`. That's independent of #52 — worth a separate issue if we want operators to author `configJson` directly in profiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)