### PR TITLE
fix(ci): publish PR image to GHCR with pr-<num>-<sha> tag

### DIFF
--- a/.github/workflows/build-scan-image.yaml
+++ b/.github/workflows/build-scan-image.yaml
@@ -14,7 +14,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  build-pr:
+    if: github.event_name == 'pull_request'
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-ko-build.yaml@main
+    with:
+      runs-on: ubuntu-latest
+      registry: ghcr.io
+      tags: pr-${{ github.event.number }}-${{ github.event.pull_request.head.sha }},pr-${{ github.event.number }}
+    secrets: inherit # pragma: allowlist secret
+
+  build-main:
+    if: github.event_name != 'pull_request'
     uses: stuttgart-things/github-workflow-templates/.github/workflows/call-ko-build.yaml@main
     with:
       runs-on: ubuntu-latest


### PR DESCRIPTION
## Symptom

Every PR-preview env for `machinery` is stuck in `ImagePullBackOff` and the gateway returns `no healthy upstream` on the preview URL. Confirmed on `homerun2-dev`:

\`\`\`
machinery-pr-41   machinery-76fcb68998-rv25c   0/1   ImagePullBackOff   0   33m
machinery-pr-59   machinery-6dcc549bc7-2w6x9   0/1   ImagePullBackOff   0   24m
\`\`\`

kubelet error on both:
\`\`\`
Failed to pull image "ghcr.io/stuttgart-things/machinery:pr-59-e90863bb363b...":
ghcr.io/stuttgart-things/machinery:pr-59-...: not found
\`\`\`

## Root cause

`build-scan-image.yaml`'s single `build` job called `call-ko-build.yaml` with no inputs, so it took the reusable's defaults — **`ttl.sh` registry** and **`latest` tag**. The PR-preview AppSet (`stuttgart-things/argocd@platforms/machinery-pr-preview/appset-machinery-pr-preview.yaml`) expects `ghcr.io/stuttgart-things/machinery:pr-<num>-<sha>`, which never exists.

The companion `Push PR Kustomize OCI` workflow already pushes the kustomize artifact to GHCR correctly — only the container-image side was broken.

## Fix

Split into the two-job shape `scout` / `omni-pitcher` / `core-catcher` use:

| Job | Trigger | Registry | Tags |
|---|---|---|---|
| `build-pr` | `pull_request` | `ghcr.io` | `pr-<num>-<sha>`, `pr-<num>` |
| `build-main` | non-PR (push/dispatch) | reusable defaults (`ttl.sh`) | `latest` (ephemeral smoke) |

## Test plan

- [x] YAML-valid; pattern matches scout/omni-pitcher (`call-ko-build.yaml` with `registry: ghcr.io` + `tags: pr-<n>-<sha>,pr-<n>`)
- [ ] After merge: rebase / push to `machinery-pr-41` and `machinery-pr-59` → `build-pr` publishes `ghcr.io/stuttgart-things/machinery:pr-<n>-<sha>` → AppSet renders → pods come up → preview URLs serve

## Refs

Preview platform: stuttgart-things/argocd@platforms/machinery-pr-preview/

🤖 Generated with [Claude Code](https://claude.com/claude-code)