### PR TITLE
docs(ci): document PR preview app workflow

### DIFF
--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -1,0 +1,117 @@
+# CI/CD
+
+This page documents the GitHub Actions pipelines that run on `machinery`,
+with a focus on the **preview app** workflow that spins up a live
+per-PR environment.
+
+## Preview app workflow
+
+Every pull request against `main` can be promoted to a live preview
+environment by attaching the `preview` label. The deployment is driven
+by an ArgoCD `ApplicationSet` living in
+[`stuttgart-things/argocd`](https://github.com/stuttgart-things/argocd)
+under `platforms/machinery-pr-preview/`, which uses a `pullRequest`
+generator to pick up labeled PRs and render them against the per-PR
+artifacts pushed from this repo.
+
+### End-to-end flow
+
+```
+                     ┌──────────────────────────────────────────────┐
+                     │ 1. PR opened against main                    │
+                     └────────────────────┬─────────────────────────┘
+                                          │
+                ┌─────────────────────────┴───────────────────────────┐
+                ▼                                                     ▼
+   build-scan-image.yaml                                  push-kustomize-pr.yaml
+   pushes ghcr.io/stuttgart-things/                       pushes ghcr.io/stuttgart-things/
+   machinery:pr-<num>-<sha>                               machinery-kustomize:pr-<num>-<sha>
+
+                                          │
+                     ┌────────────────────┴─────────────────────────┐
+                     │ 2. Maintainer adds the `preview` label       │
+                     └────────────────────┬─────────────────────────┘
+                                          │
+                ┌─────────────────────────┴───────────────────────────┐
+                ▼                                                     ▼
+   comment-preview-url.yaml                                ArgoCD ApplicationSet
+   posts the preview URL as a                              (stuttgart-things/argocd)
+   PR comment                                              renders the kustomize OCI
+                                                           artifact at the matching
+                                                           pr-<num>-<sha> tag and
+                                                           deploys it into the
+                                                           machinery-pr-<num> namespace
+
+                                          │
+                     ┌────────────────────┴─────────────────────────┐
+                     │ 3. PR closed (merged or not)                 │
+                     └────────────────────┬─────────────────────────┘
+                                          ▼
+                              cleanup-pr-artifacts.yaml
+                              deletes the pr-<num>-* tags
+                              from both GHCR packages
+```
+
+### The artifacts
+
+The AppSet keys on **two** OCI artifacts that share the same tag:
+
+| Artifact | Workflow | Tag |
+|---|---|---|
+| Runtime image | `build-scan-image.yaml` (ko build) | `pr-<num>-<sha>` (and `pr-<num>`) |
+| Kustomize manifests | `push-kustomize-pr.yaml` | `pr-<num>-<sha>` |
+
+The `<sha>` part of the tag matches `.head_sha` from Argo's
+`pullRequest` generator, so the AppSet substitutes it verbatim — no
+massaging needed.
+
+### The preview URL
+
+When the `preview` label is attached (or a PR is reopened while still
+carrying the label), `comment-preview-url.yaml` posts a comment of the
+form:
+
+```
+machinery-pr-<num>.homerun2-dev.sthings-vsphere.labul.sva.de
+```
+
+The hostname prefix (`machinery-pr`), domain
+(`homerun2-dev.sthings-vsphere.labul.sva.de`), and namespace prefix
+(`machinery-pr`) are configured in
+`.github/workflows/comment-preview-url.yaml` and **must** match the
+AppSet template in `stuttgart-things/argocd`.
+
+### Trigger semantics
+
+`comment-preview-url.yaml` listens to `reopened` and `labeled` —
+**not** `opened`. The reason: when a PR is created with the `preview`
+label already attached, GitHub fires `opened` and `labeled`
+back-to-back and the URL comment ends up duplicated. The `labeled`
+event covers the at-creation case on its own.
+
+### Cleanup
+
+`cleanup-pr-artifacts.yaml` fires on `pull_request: closed` and
+removes the `pr-<num>-*` tags from both `machinery` and
+`machinery-kustomize` on GHCR. ArgoCD tears down the namespace on its
+own once the PR drops out of the generator's result set.
+
+## Other pipelines
+
+| Workflow | Trigger | Purpose |
+|---|---|---|
+| `build-test.yaml` | push to `main`, PR | `go build` + `go test -race` + `go vet` |
+| `e2e.yaml` | push to `main`, PR | kind-based end-to-end (`task e2e`) on self-hosted runner |
+| `lint-repo.yaml` | push to `main`, PR | Repository linting via Dagger |
+| `build-scan-image.yaml` | push to `main`, PR | ko build + scan; PR builds get `pr-*` tags |
+| `release.yaml` | after successful main image build | semantic-release + tagged kustomize OCI push |
+| `pages.yaml` | after successful release | Publish MkDocs site to GitHub Pages |
+
+## Trying it out
+
+1. Open a PR against `main`.
+2. Wait for `build-scan-image` and `push-kustomize-pr` to go green —
+   the artifacts have to exist before Argo can pull them.
+3. Apply the `preview` label.
+4. A PR comment with the live URL shows up shortly after Argo syncs.
+5. Close (or merge) the PR to tear everything down.


### PR DESCRIPTION
## Summary
- Add `docs/ci-cd.md` walking through the per-PR preview app workflow end-to-end: build artifacts (`build-scan-image`, `push-kustomize-pr`), label trigger, ArgoCD AppSet consumption, URL comment, and cleanup.
- Also tabulates the supporting pipelines (`build-test`, `e2e`, `lint-repo`, `release`, `pages`) so the doc is the single landing page for "how does CI/CD work here".
- Opening this PR with the `preview` label attached doubles as a live test of the flow it documents — the URL comment should land on this PR once Argo syncs.

## Test plan
- [ ] `build-scan-image` pushes `ghcr.io/stuttgart-things/machinery:pr-<num>-<sha>`
- [ ] `push-kustomize-pr` pushes `ghcr.io/stuttgart-things/machinery-kustomize:pr-<num>-<sha>`
- [ ] `comment-preview-url` posts the `machinery-pr-<num>.homerun2-dev...` URL as a PR comment
- [ ] ArgoCD AppSet reconciles a `machinery-pr-<num>` namespace and the URL responds
- [ ] On close, `cleanup-pr-artifacts` removes the `pr-<num>-*` tags from both GHCR packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)