### PR TITLE
chore(preview): docs, examples, and e2e skip for PR-preview envs

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -16,6 +16,12 @@ concurrency:
 jobs:
   e2e:
     name: e2e (kind + machinery + test CRDs)
+    # PRs labelled `preview` get a real-cluster deployment on homerun2-dev
+    # via the AppSet in stuttgart-things/argocd@platforms/machinery-pr-preview,
+    # which exercises the same code paths against a richer environment.
+    # Running kind on top of that doubles the runner cost (and the wait)
+    # without adding much signal — skip.
+    if: github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'preview')
     # Dedicated kind-only runners (kind-testing-runner-1 / -2). The
     # concurrency group above keeps only one job running at a time; the
     # second runner is hot spare or room for a sibling project. Same pattern

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ message ResourceStatus {
 
 ## Configuration
 
-Resource types are configurable via JSON. Set `MACHINERY_CONFIG` to load a custom config file.
+Resource types are configurable via JSON. Set `MACHINERY_CONFIG` to load a custom config file. Drop-in examples for common watch sets (VsphereVM, platform XRs, AnsibleRun, …) live in [`examples/configs/`](examples/configs/).
 
 ### Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,10 @@ Machinery can be deployed via [Flux CD](https://fluxcd.io/) using OCI-based Kust
 
 The upstream app manifests define the base deployment, while per-cluster configs customize version, hostname, gateway, and resource configuration via `postBuild.substitute` and strategic merge patches.
 
+### PR preview environments
+
+Labelling a pull request with `preview` triggers `push-kustomize-pr.yaml` to publish `pr-<n>-<sha>`-tagged image and kustomize artifacts. An Argo `ApplicationSet` ([`stuttgart-things/argocd@platforms/machinery-pr-preview`](https://github.com/stuttgart-things/argocd/tree/main/platforms/machinery-pr-preview)) then deploys them onto opt-in clusters and posts the preview URL back on the PR. Closing the PR tears the environment down and `cleanup-pr-artifacts.yaml` removes the OCI tags.
+
 ### Container Image
 
 Built with [ko](https://ko.build/) on `cgr.dev/chainguard/static:latest` (distroless). Version, commit, and date are injected via ldflags at build time.

--- a/config_test.go
+++ b/config_test.go
@@ -102,6 +102,30 @@ func TestDefaultConfig(t *testing.T) {
 	}
 }
 
+// Each file under examples/configs/ is published as a recommended drop-in
+// for MACHINERY_CONFIG. They MUST parse cleanly via loadConfig — schema
+// drift here breaks users who copy them, so guard it in CI.
+func TestExampleConfigsParse(t *testing.T) {
+	matches, err := filepath.Glob("examples/configs/*.json")
+	if err != nil {
+		t.Fatalf("globbing examples/configs: %v", err)
+	}
+	if len(matches) == 0 {
+		t.Fatal("no example configs found under examples/configs/")
+	}
+	for _, path := range matches {
+		t.Run(filepath.Base(path), func(t *testing.T) {
+			cfg, err := loadConfig(path)
+			if err != nil {
+				t.Fatalf("loadConfig(%s): %v", path, err)
+			}
+			if len(cfg.Resources) == 0 {
+				t.Errorf("%s defines no resources", path)
+			}
+		})
+	}
+}
+
 func TestResourceKindToGVR(t *testing.T) {
 	rk := ResourceKind{
 		Group:    "resources.stuttgart-things.com",

--- a/examples/configs/README.md
+++ b/examples/configs/README.md
@@ -1,0 +1,84 @@
+# Example machinery configs
+
+Drop-in `config.json` files for the `MACHINERY_CONFIG` env var. Pick the
+one closest to your needs and edit — `group`/`version`/`resource` map
+1:1 to a Kubernetes GVR, dot-paths into the CR object pluck values for
+the dashboard.
+
+| File | Watches | Useful when |
+|---|---|---|
+| [`default.json`](default.json) | `HarvesterVM`, `StoragePlatform`, `NetworkIntegration` | starter — same as the binary's built-in `defaultConfig()` |
+| [`vsphere-vms.json`](vsphere-vms.json) | `VsphereVM`, `HarvesterVM` | VM-provisioning view; includes `infoFields` for the detail pane |
+| [`platforms.json`](platforms.json) | `StoragePlatform`, `NetworkIntegration`, `SecurityPlatform`, `AnsibleRun` | platform/automation rollout view across XRs |
+
+## Schema (per kind)
+
+```jsonc
+"<DisplayName>": {
+  "group":           "resources.stuttgart-things.com",   // GVR.group
+  "version":         "v1alpha1",                          // GVR.version
+  "resource":        "vspherevms",                        // GVR.resource (plural, lowercase)
+  "connectionField": "status.share.ip",                   // optional — primary value shown in the table
+  "statusFields":    ["status.share.ip"],                 // optional — extra columns appended to connection details
+  "infoFields": [                                         // optional — rows in the row-click detail panel
+    { "label": "Datacenter", "path": "spec.vm.datacenter" }
+  ]
+}
+```
+
+Dot-paths support `string`, `bool`, and `int64` values automatically.
+Missing paths render as empty.
+
+## Deploying a config
+
+### Option A — flux / kustomize (any cluster)
+
+1. Materialise the JSON as a ConfigMap in the destination namespace:
+
+   ```bash
+   kubectl -n machinery create configmap machinery-config \
+     --from-file=config.json=examples/configs/platforms.json
+   ```
+
+2. Patch the Deployment to mount it (see the example below).
+
+### Option B — Argo CD via `apps/machinery/install` chart
+
+Pass the new `config.fromConfigMap` value (added in
+[stuttgart-things/argocd#139](https://github.com/stuttgart-things/argocd/pull/139)):
+
+```yaml
+helm:
+  values: |
+    config:
+      fromConfigMap: machinery-config
+```
+
+The chart mounts the named ConfigMap at `/etc/machinery` and sets
+`MACHINERY_CONFIG=/etc/machinery/config.json`. The ConfigMap itself
+still has to be provisioned out-of-band (Kyverno generate / sealed
+secret / ESO / `kubectl apply`).
+
+## Pod patch reference
+
+If you wire the ConfigMap up by hand (Option A) rather than through
+the chart, this is the Deployment overlay:
+
+```yaml
+spec:
+  template:
+    spec:
+      containers:
+        - name: machinery
+          env:
+            - name: MACHINERY_CONFIG
+              value: /etc/machinery/config.json
+          volumeMounts:
+            - name: machinery-config
+              mountPath: /etc/machinery
+              readOnly: true
+      volumes:
+        - name: machinery-config
+          configMap:
+            name: machinery-config
+```

--- a/examples/configs/default.json
+++ b/examples/configs/default.json
@@ -1,0 +1,35 @@
+{
+  "port": 50051,
+  "httpPort": 8080,
+  "resources": {
+    "HarvesterVM": {
+      "group": "resources.stuttgart-things.com",
+      "version": "v1alpha1",
+      "resource": "harvestervms",
+      "connectionField": "status.vm.name",
+      "statusFields": [
+        "status.volume.ready",
+        "status.cloudInit.ready",
+        "status.vm.ready"
+      ]
+    },
+    "StoragePlatform": {
+      "group": "resources.stuttgart-things.com",
+      "version": "v1alpha1",
+      "resource": "storageplatforms",
+      "statusFields": [
+        "status.installed",
+        "status.observedVersion"
+      ]
+    },
+    "NetworkIntegration": {
+      "group": "resources.stuttgart-things.com",
+      "version": "v1alpha1",
+      "resource": "networkintegrations",
+      "statusFields": [
+        "status.installed",
+        "status.observedVersion"
+      ]
+    }
+  }
+}

--- a/examples/configs/platforms.json
+++ b/examples/configs/platforms.json
@@ -1,0 +1,55 @@
+{
+  "port": 50051,
+  "httpPort": 8080,
+  "resources": {
+    "StoragePlatform": {
+      "group": "resources.stuttgart-things.com",
+      "version": "v1alpha1",
+      "resource": "storageplatforms",
+      "statusFields": [
+        "status.installed",
+        "status.observedVersion"
+      ],
+      "infoFields": [
+        { "label": "Provider", "path": "spec.provider" },
+        { "label": "Version",  "path": "spec.version" }
+      ]
+    },
+    "NetworkIntegration": {
+      "group": "resources.stuttgart-things.com",
+      "version": "v1alpha1",
+      "resource": "networkintegrations",
+      "statusFields": [
+        "status.installed",
+        "status.observedVersion"
+      ],
+      "infoFields": [
+        { "label": "Provider", "path": "spec.provider" },
+        { "label": "Version",  "path": "spec.version" }
+      ]
+    },
+    "SecurityPlatform": {
+      "group": "resources.stuttgart-things.com",
+      "version": "v1alpha1",
+      "resource": "securityplatforms",
+      "statusFields": [
+        "status.installed",
+        "status.observedVersion"
+      ]
+    },
+    "AnsibleRun": {
+      "group": "resources.stuttgart-things.com",
+      "version": "v1alpha1",
+      "resource": "ansibleruns",
+      "connectionField": "status.lastRunTime",
+      "statusFields": [
+        "status.phase",
+        "status.observedGeneration"
+      ],
+      "infoFields": [
+        { "label": "Playbook", "path": "spec.playbook" },
+        { "label": "Inventory","path": "spec.inventory" }
+      ]
+    }
+  }
+}

--- a/examples/configs/vsphere-vms.json
+++ b/examples/configs/vsphere-vms.json
@@ -1,0 +1,39 @@
+{
+  "port": 50051,
+  "httpPort": 8080,
+  "resources": {
+    "VsphereVM": {
+      "group": "resources.stuttgart-things.com",
+      "version": "v1alpha1",
+      "resource": "vspherevms",
+      "connectionField": "status.share.ip",
+      "statusFields": [
+        "status.share.ip"
+      ],
+      "infoFields": [
+        { "label": "Datacenter", "path": "spec.vm.datacenter" },
+        { "label": "Template",   "path": "spec.vm.template" },
+        { "label": "Network",    "path": "spec.vm.network" },
+        { "label": "CPU",        "path": "spec.vm.numCPUs" },
+        { "label": "Memory MB",  "path": "spec.vm.memoryMB" }
+      ]
+    },
+    "HarvesterVM": {
+      "group": "resources.stuttgart-things.com",
+      "version": "v1alpha1",
+      "resource": "harvestervms",
+      "connectionField": "status.vm.name",
+      "statusFields": [
+        "status.volume.ready",
+        "status.cloudInit.ready",
+        "status.vm.ready"
+      ],
+      "infoFields": [
+        { "label": "Image",   "path": "spec.vm.image" },
+        { "label": "CPU",     "path": "spec.vm.cpu" },
+        { "label": "Memory",  "path": "spec.vm.memory" },
+        { "label": "Disk GB", "path": "spec.vm.diskSizeGB" }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Bundles three small follow-ups from the `chore/test-pr-preview` scratch branch that were left behind after the main preview-env workflows landed in #53 / #58 / #59:

1. **`docs: mention PR preview environments`** — adds a README section so the feature is discoverable; current `main` has the workflows but no doc pointer.
2. **`ci(e2e): skip kind workflow on PRs labelled preview`** — `preview`-labelled PRs already get a real-cluster deployment on homerun2-dev via the AppSet, so the kind e2e is duplicate work (and doubles self-hosted-runner wall-time without adding signal).
3. **`docs(examples): example MACHINERY_CONFIG files for common watch sets`** — drops `examples/configs/{default,platforms,vsphere-vms}.json` plus a README, and adds a `config_test.go` test that parses each example to keep them honest.

The two commits from the scratch branch that **aren't** here:
- `fix(ci): tag PR builds with pr-<n>-<sha>` — already merged via #60.
- `chore: re-trigger workflows after upstream dagger bump` — empty/no-op commit.

## Test plan

- [x] `go test ./...` passes (the new `config_test.go` exercises each example file).
- [x] `kcl run kcl/main.k -Y tests/kcl-deploy-profile.yaml` renders cleanly.
- [ ] On this PR's CI: the kind e2e workflow is **skipped** (because `preview` is set), proving the e2e change works.
- [ ] Preview env spins up and the URL comment posts via the `labeled` trigger (#59).

🤖 Generated with [Claude Code](https://claude.com/claude-code)