### PR TITLE
fix: surface Gateway API status + render slice info fields on HTTPRoute

### DIFF
--- a/main.go
+++ b/main.go
@@ -212,25 +212,65 @@ func getResourceStatus(obj *unstructured.Unstructured) (string, bool) {
 	if err != nil {
 		return fmt.Sprintf("Error reading conditions: %v", err), false
 	}
-	if !found {
-		return "No conditions found", false
+	if found {
+		for _, c := range conditions {
+			condition, ok := c.(map[string]any)
+			if !ok {
+				continue
+			}
+
+			if condition["type"] == "Ready" {
+				if condition["status"] == "True" {
+					return "Ready", true
+				}
+				return "Not Ready", false
+			}
+		}
+		return "Not Ready", false
 	}
 
-	for _, c := range conditions {
-		condition, ok := c.(map[string]any)
+	// Gateway API kinds (HTTPRoute, GRPCRoute, …) scope conditions per
+	// parent at status.parents[*].conditions. There is no "Ready" type;
+	// per the spec readiness is Accepted=True + ResolvedRefs=True on
+	// every attached parent. Report Ready iff every condition is True,
+	// otherwise return the first non-True condition as the message.
+	parents, parentsFound, err := unstructured.NestedSlice(obj.Object, "status", "parents")
+	if err != nil {
+		return fmt.Sprintf("Error reading parents: %v", err), false
+	}
+	if !parentsFound {
+		return "No conditions found", false
+	}
+	var seen int
+	for _, p := range parents {
+		pm, ok := p.(map[string]any)
 		if !ok {
 			continue
 		}
-
-		if condition["type"] == "Ready" {
-			if condition["status"] == "True" {
-				return "Ready", true
+		pconds, ok2, err := unstructured.NestedSlice(pm, "conditions")
+		if err != nil || !ok2 {
+			continue
+		}
+		for _, c := range pconds {
+			cm, ok := c.(map[string]any)
+			if !ok {
+				continue
 			}
-			return "Not Ready", false
+			seen++
+			if cm["status"] != "True" {
+				t, _ := cm["type"].(string)
+				r, _ := cm["reason"].(string)
+				if r != "" {
+					return fmt.Sprintf("%s: %s", t, r), false
+				}
+				return t, false
+			}
 		}
 	}
-
-	return "Not Ready", false
+	if seen == 0 {
+		return "No conditions found", false
+	}
+	return "Ready", true
 }
 
 func getConnectionDetails(obj *unstructured.Unstructured, fieldPath string) string {
@@ -328,5 +368,37 @@ func getNestedField(obj *unstructured.Unstructured, fieldPath string) string {
 		return fmt.Sprintf("%d", intVal)
 	}
 
+	// Slice fallback. Gateway API surfaces useful fields as arrays:
+	// []string (e.g. HTTPRoute.spec.hostnames) and []map (e.g.
+	// HTTPRoute.spec.parentRefs). Render strings joined, maps as
+	// namespace/name pairs so the UI shows something usable.
+	slice, found, err := unstructured.NestedSlice(obj.Object, segments...)
+	if err == nil && found {
+		var parts []string
+		for _, item := range slice {
+			switch v := item.(type) {
+			case string:
+				parts = append(parts, v)
+			case map[string]any:
+				if s := summarizeRef(v); s != "" {
+					parts = append(parts, s)
+				}
+			}
+		}
+		return strings.Join(parts, ", ")
+	}
+
+	return ""
+}
+
+func summarizeRef(m map[string]any) string {
+	name, _ := m["name"].(string)
+	ns, _ := m["namespace"].(string)
+	if name != "" && ns != "" {
+		return fmt.Sprintf("%s/%s", ns, name)
+	}
+	if name != "" {
+		return name
+	}
 	return ""
 }

--- a/main_test.go
+++ b/main_test.go
@@ -220,6 +220,55 @@ func TestGetResourceStatus(t *testing.T) {
 			wantMsg:   "Not Ready",
 			wantReady: false,
 		},
+		{
+			name: "gateway api parent conditions all true",
+			obj: map[string]any{
+				"metadata": map[string]any{"name": "test"},
+				"status": map[string]any{
+					"parents": []any{
+						map[string]any{
+							"conditions": []any{
+								map[string]any{"type": "Accepted", "status": "True"},
+								map[string]any{"type": "ResolvedRefs", "status": "True"},
+							},
+						},
+					},
+				},
+			},
+			wantMsg:   "Ready",
+			wantReady: true,
+		},
+		{
+			name: "gateway api parent condition not accepted",
+			obj: map[string]any{
+				"metadata": map[string]any{"name": "test"},
+				"status": map[string]any{
+					"parents": []any{
+						map[string]any{
+							"conditions": []any{
+								map[string]any{"type": "Accepted", "status": "False", "reason": "NoMatchingParent"},
+								map[string]any{"type": "ResolvedRefs", "status": "True"},
+							},
+						},
+					},
+				},
+			},
+			wantMsg:   "Accepted: NoMatchingParent",
+			wantReady: false,
+		},
+		{
+			name: "gateway api parent without conditions",
+			obj: map[string]any{
+				"metadata": map[string]any{"name": "test"},
+				"status": map[string]any{
+					"parents": []any{
+						map[string]any{"parentRef": map[string]any{"name": "gw"}},
+					},
+				},
+			},
+			wantMsg:   "No conditions found",
+			wantReady: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -301,10 +350,17 @@ func TestGetNestedField(t *testing.T) {
 	obj := &unstructured.Unstructured{Object: map[string]any{
 		"metadata": map[string]any{"name": "test"},
 		"status": map[string]any{
-			"name":    "my-resource",
-			"ready":   true,
-			"count":   int64(42),
-			"nested":  map[string]any{"deep": "value"},
+			"name":   "my-resource",
+			"ready":  true,
+			"count":  int64(42),
+			"nested": map[string]any{"deep": "value"},
+		},
+		"spec": map[string]any{
+			"hostnames": []any{"a.example.com", "b.example.com"},
+			"parentRefs": []any{
+				map[string]any{"name": "gateway-a", "namespace": "default"},
+				map[string]any{"name": "gateway-b"},
+			},
 		},
 	}}
 
@@ -318,6 +374,8 @@ func TestGetNestedField(t *testing.T) {
 		{"int64 field", "status.count", "42"},
 		{"nested field", "status.nested.deep", "value"},
 		{"missing field", "status.missing", ""},
+		{"slice of strings (hostnames)", "spec.hostnames", "a.example.com, b.example.com"},
+		{"slice of maps (parentRefs)", "spec.parentRefs", "default/gateway-a, gateway-b"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- `getResourceStatus` now falls back to `status.parents[*].conditions[*]` when `status.conditions` is absent — Gateway API scopes conditions per parent (no `Ready` type), so this is the only way HTTPRoute/GRPCRoute/TLSRoute ever surface as anything other than "No conditions found".
- `getNestedField` learned to render slices: `[]string` joins comma-separated (e.g. `spec.hostnames`), `[]map` collapses to `<namespace>/<name>` pairs (e.g. `spec.parentRefs`). Without this, the only useful HTTPRoute info fields came back empty.
- Behaviour for flat `status.conditions` is unchanged — kinds like crossplane XRs that report `Available=True` before `Ready=True` keep their strict-`Ready` requirement, so no false positives.
- Tests added for both new paths.

## Surfaced by
The `machinery-pr-61` preview env after `stuttgart-things/argocd#155` healed it. Certificate cards rendered with full Connection + Details rows; HTTPRoute showed `Not Ready / No conditions found` and an empty Details block.

## Test plan
- [x] `go test -race ./...` green locally (full suite, including the new sub-tests)
- [x] `go vet ./...` clean
- [ ] Once this PR's preview env spins up: HTTPRoute card shows `Ready`, Details show `Hostnames: machinery-pr-<n>.…` and `Parent: default/homerun2-dev-gateway`
- [ ] Cert-manager Certificate cards still render exactly as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)