### PR TITLE
docs(config): add Gateway API example + document slice rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,9 @@ Each resource kind supports:
 - **`statusFields`** — dot-separated paths displayed as status indicators
 - **`infoFields`** — labeled fields for the detail view, each with a `label` and `path`
 
-Field extraction supports string, bool, and int64 types automatically.
+Field extraction supports string, bool, and int64 scalars, plus slices: `[]string` joins comma-separated, `[]map` collapses to `namespace/name` pairs (useful for Gateway API's `spec.hostnames` and `spec.parentRefs`). For Gateway API kinds, readiness falls back from `status.conditions` to `status.parents[*].conditions[*]` automatically.
+
+See [`examples/configs/`](examples/configs/) for drop-in JSON files, including a Gateway API example.
 
 ```json
 {

--- a/examples/configs/README.md
+++ b/examples/configs/README.md
@@ -10,6 +10,7 @@ the dashboard.
 | [`default.json`](default.json) | `HarvesterVM`, `StoragePlatform`, `NetworkIntegration` | starter — same as the binary's built-in `defaultConfig()` |
 | [`vsphere-vms.json`](vsphere-vms.json) | `VsphereVM`, `HarvesterVM` | VM-provisioning view; includes `infoFields` for the detail pane |
 | [`platforms.json`](platforms.json) | `StoragePlatform`, `NetworkIntegration`, `SecurityPlatform`, `AnsibleRun` | platform/automation rollout view across XRs |
+| [`gateway-api.json`](gateway-api.json) | cert-manager `Certificate`, ESO `ExternalSecret`, Gateway API `HTTPRoute` | platform-services view; exercises the Gateway API per-parent status path and slice-valued info fields |
 
 ## Schema (per kind)
 
@@ -26,8 +27,24 @@ the dashboard.
 }
 ```
 
-Dot-paths support `string`, `bool`, and `int64` values automatically.
-Missing paths render as empty.
+Dot-paths support `string`, `bool`, and `int64` scalars, plus slices:
+`[]string` joins comma-separated (e.g. `spec.hostnames`), `[]map`
+collapses to `namespace/name` pairs when the items carry those keys
+(e.g. `spec.parentRefs`). Missing paths render as empty. Array
+indexing (`spec.parentRefs[0].name`) is not supported — point at the
+parent path and let the renderer flatten it.
+
+## Readiness
+
+The dashboard's `Ready` badge comes from `status.conditions[*]` —
+specifically the `type: Ready` entry (standard kubernetes /
+crossplane convention). For Gateway API kinds (`HTTPRoute`,
+`GRPCRoute`, …) there is no `Ready` type; conditions live per parent
+at `status.parents[*].conditions[*]` instead. machinery falls back to
+that path automatically and reports Ready when every parent condition
+is `True`, otherwise surfaces the first non-`True` condition as
+`<Type>: <Reason>`. No config knob — the fallback engages whenever
+flat `status.conditions` is absent.
 
 ## Deploying a config
 

--- a/examples/configs/gateway-api.json
+++ b/examples/configs/gateway-api.json
@@ -1,0 +1,40 @@
+{
+  "port": 50051,
+  "httpPort": 8080,
+  "resources": {
+    "Certificate": {
+      "group": "cert-manager.io",
+      "version": "v1",
+      "resource": "certificates",
+      "connectionField": "status.notAfter",
+      "statusFields": ["status.renewalTime"],
+      "infoFields": [
+        { "label": "Issuer",     "path": "spec.issuerRef.name" },
+        { "label": "CommonName", "path": "spec.commonName" },
+        { "label": "Expires",    "path": "status.notAfter" },
+        { "label": "Renews",     "path": "status.renewalTime" }
+      ]
+    },
+    "ExternalSecret": {
+      "group": "external-secrets.io",
+      "version": "v1beta1",
+      "resource": "externalsecrets",
+      "connectionField": "status.refreshTime",
+      "statusFields": ["status.syncedResourceVersion"],
+      "infoFields": [
+        { "label": "Store",     "path": "spec.secretStoreRef.name" },
+        { "label": "Target",    "path": "spec.target.name" },
+        { "label": "Refreshed", "path": "status.refreshTime" }
+      ]
+    },
+    "HTTPRoute": {
+      "group": "gateway.networking.k8s.io",
+      "version": "v1",
+      "resource": "httproutes",
+      "connectionField": "spec.hostnames",
+      "infoFields": [
+        { "label": "Parent", "path": "spec.parentRefs" }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `examples/configs/gateway-api.json` — drop-in config watching cert-manager `Certificate`, ESO `ExternalSecret`, and Gateway API `HTTPRoute`. Mirrors what the `machinery-pr-preview` AppSet on `homerun2-dev` runs, so it doubles as a known-good reference.
- Updates `examples/configs/README.md`:
  - Lists the new example in the file table.
  - Expands the type-support note: scalars **plus** `[]string` (comma-joined) and `[]map` (collapsed to `namespace/name`).
  - Adds a **Readiness** section documenting the Gateway API per-parent conditions fallback (`status.parents[*].conditions[*]`) introduced by #63.
- Same correction to the inline schema note in `README.md` plus a pointer at `examples/configs/`.

## Why now
After #63 landed, the example library was the last place still claiming "string/bool/int64 only" with no Gateway API example — anyone trying to set up an HTTPRoute view would have to read the code to find out the slice-rendering and per-parent-conditions behaviour. This closes that gap.

## Test plan
- [x] `jq` validates `examples/configs/gateway-api.json`
- [ ] Preview env spun up by this PR's `preview` label renders the dashboard with the default config (no behaviour change — docs/example only)
- [ ] If you point a machinery deployment at `examples/configs/gateway-api.json` on a cluster with cert-manager + ESO + Gateway API installed, the three kinds appear and HTTPRoute reports `Ready` via the per-parent fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)