### PR TITLE
feat(web): multi-select kind+namespace filters, fix stale-poll race

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Client (gRPC)  ──> gRPC :50051 ─┘        (dynamic client)
 
 HTMX-based dashboard at `http://localhost:8080`:
 
-- Auto-refreshing resource table (5s interval)
-- Filter by resource kind
+- Auto-refreshing resource table (5s interval, stale-response guarded)
+- Multi-select filters by resource kind and namespace
 - Clickable rows for detail view with info fields
 - Ready/Not Ready status badges
 - Build info footer (version, commit, date)

--- a/web.go
+++ b/web.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"sort"
+	"strings"
 
 	resourceservice "github.com/stuttgart-things/maschinist/resourceservice"
 )
@@ -43,6 +44,12 @@ type resourceData struct {
 
 type resourceListData struct {
 	Resources []resourceData
+	// Namespaces is the sorted unique set of namespaces present in the
+	// current (kind-filtered) backend result, *before* the user's
+	// namespace filter is applied. The template emits it as JSON in a
+	// hidden data attribute so the namespace chip row stays a function
+	// of "what could match", not "what currently matches".
+	Namespaces []string
 }
 
 type detailData struct {
@@ -106,8 +113,25 @@ func (w *webServer) handleResources(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Namespace filter is applied web-side rather than in the gRPC
+	// handler: keeps GetResources protocol-stable for the gRPC client,
+	// and the kind-filtered list is already in memory.
+	nsFilter := parseCSV(r.URL.Query().Get("namespace"))
+
+	nsSet := map[string]struct{}{}
 	data := resourceListData{}
 	for _, res := range resp.Resources {
+		nsSet[res.Namespace] = struct{}{}
+		// Cluster-scoped resources (Namespace=="") are always shown,
+		// regardless of the namespace filter — there's no useful chip
+		// to toggle them on the UI side, and silently hiding them when
+		// any namespace is selected would surprise users mixing
+		// namespace-scoped and cluster-scoped kinds.
+		if len(nsFilter) > 0 && res.Namespace != "" {
+			if _, ok := nsFilter[res.Namespace]; !ok {
+				continue
+			}
+		}
 		data.Resources = append(data.Resources, resourceData{
 			Name:              res.Name,
 			Kind:              res.Kind,
@@ -118,12 +142,29 @@ func (w *webServer) handleResources(rw http.ResponseWriter, r *http.Request) {
 			InfoFields:        res.InfoFields,
 		})
 	}
+	for ns := range nsSet {
+		data.Namespaces = append(data.Namespaces, ns)
+	}
+	sort.Strings(data.Namespaces)
 
 	rw.Header().Set("Content-Type", "text/html; charset=utf-8")
 	if err := w.templates.ExecuteTemplate(rw, "resources.html", data); err != nil {
 		slog.Error("failed to render resources", "error", err)
 		http.Error(rw, "Internal Server Error", http.StatusInternalServerError)
 	}
+}
+
+func parseCSV(v string) map[string]struct{} {
+	if v == "" {
+		return nil
+	}
+	out := map[string]struct{}{}
+	for _, p := range strings.Split(v, ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			out[p] = struct{}{}
+		}
+	}
+	return out
 }
 
 func (w *webServer) handleDetail(rw http.ResponseWriter, r *http.Request) {

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -56,8 +56,23 @@
         .filters {
             display: flex;
             gap: 0.5rem;
-            margin-bottom: 1.5rem;
+            margin-bottom: 0.75rem;
             flex-wrap: wrap;
+            align-items: center;
+        }
+        .filters:last-of-type { margin-bottom: 1.5rem; }
+        .filter-label {
+            font-size: 0.75rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+            margin-right: 0.25rem;
+            min-width: 5rem;
+        }
+        .filter-empty {
+            font-size: 0.8rem;
+            color: var(--text-muted);
+            font-style: italic;
         }
         .filter-btn {
             padding: 0.4rem 1rem;
@@ -247,24 +262,24 @@
             </div>
         </header>
 
-        <div class="filters">
-            <button class="filter-btn active"
-                    hx-get="/resources?kind=*"
-                    hx-target="#resource-list"
-                    hx-indicator="#spinner"
-                    onclick="setActive(this)">All</button>
+        <div class="filters" id="kind-filters">
+            <span class="filter-label">Kind</span>
+            <button class="filter-btn kind-filter active" data-value="*">All</button>
             {{range .Kinds}}
-            <button class="filter-btn"
-                    hx-get="/resources?kind={{.}}"
-                    hx-target="#resource-list"
-                    hx-indicator="#spinner"
-                    onclick="setActive(this)">{{.}}</button>
+            <button class="filter-btn kind-filter" data-value="{{.}}">{{.}}</button>
             {{end}}
+        </div>
+
+        <div class="filters" id="namespace-filters">
+            <span class="filter-label">Namespace</span>
+            <button class="filter-btn ns-filter active" data-value="*">All</button>
+            <span class="filter-empty" id="ns-empty">no namespaces yet — refreshing</span>
         </div>
 
         <div id="resource-list"
              hx-get="/resources?kind=*"
-             hx-trigger="load, every 5s"
+             hx-trigger="load, every 5s, filterChange"
+             hx-sync="this:abort"
              hx-indicator="#spinner">
         </div>
 
@@ -277,14 +292,103 @@
     </div>
 
     <script>
-        function setActive(btn) {
-            document.querySelectorAll('.filter-btn').forEach(b => b.classList.remove('active'));
-            btn.classList.add('active');
-            // Update the auto-refresh URL
+        // Filter state owned by the page, not the server. Each chip
+        // toggles membership in the relevant set; an empty set means
+        // "no filter" → server returns everything for that axis.
+        const state = { kinds: new Set(), namespaces: new Set() };
+
+        function buildURL() {
+            const p = new URLSearchParams();
+            p.set('kind', state.kinds.size ? [...state.kinds].join(',') : '*');
+            if (state.namespaces.size) {
+                p.set('namespace', [...state.namespaces].join(','));
+            }
+            return '/resources?' + p.toString();
+        }
+
+        function refreshNow() {
             const list = document.getElementById('resource-list');
-            const url = btn.getAttribute('hx-get');
-            list.setAttribute('hx-get', url);
-            htmx.process(list);
+            list.setAttribute('hx-get', buildURL());
+            // `filterChange` is one of the hx-trigger events on the
+            // list; firing it kicks off a fresh request. The element's
+            // hx-sync="this:abort" cancels any in-flight every-5s poll
+            // so a stale response can't overwrite the new one.
+            htmx.trigger(list, 'filterChange');
+        }
+
+        function syncAllButton(rowId, set) {
+            const allBtn = document.querySelector(`#${rowId} [data-value="*"]`);
+            if (!allBtn) return;
+            if (set.size === 0) allBtn.classList.add('active');
+            else allBtn.classList.remove('active');
+        }
+
+        // Single delegated handler for both filter rows.
+        document.addEventListener('click', e => {
+            const btn = e.target.closest('.filter-btn');
+            if (!btn) return;
+            const rowId = btn.closest('.filters')?.id;
+            if (rowId !== 'kind-filters' && rowId !== 'namespace-filters') return;
+            const set = rowId === 'kind-filters' ? state.kinds : state.namespaces;
+            const value = btn.dataset.value;
+            if (value === '*') {
+                set.clear();
+                btn.parentElement.querySelectorAll('.filter-btn')
+                    .forEach(b => b.classList.remove('active'));
+                btn.classList.add('active');
+            } else {
+                if (set.has(value)) {
+                    set.delete(value);
+                    btn.classList.remove('active');
+                } else {
+                    set.add(value);
+                    btn.classList.add('active');
+                }
+                syncAllButton(rowId, set);
+            }
+            refreshNow();
+        });
+
+        // Namespace chips are dynamic — re-derived from each /resources
+        // response. The chip row in the markup is a placeholder; this
+        // re-renders it on every swap, preserving the user's selection.
+        document.body.addEventListener('htmx:afterSwap', e => {
+            if (e.target.id !== 'resource-list') return;
+            const data = e.target.querySelector('#ns-data');
+            if (!data) return;
+            let namespaces;
+            try { namespaces = JSON.parse(data.dataset.namespaces); }
+            catch { namespaces = []; }
+            renderNamespaceChips(namespaces);
+        });
+
+        function renderNamespaceChips(namespaces) {
+            const row = document.getElementById('namespace-filters');
+            const html = ['<span class="filter-label">Namespace</span>'];
+            html.push(
+                `<button class="filter-btn ns-filter ${state.namespaces.size === 0 ? 'active' : ''}" data-value="*">All</button>`
+            );
+            // Cluster-scoped resources have namespace=""; the server
+            // emits them in the metadata array but they're not
+            // filterable here — there's no useful chip label for them
+            // and the namespace filter always lets them through (see
+            // handleResources). UI-side we just skip the empty entry.
+            const filterable = namespaces.filter(ns => ns !== '');
+            if (filterable.length === 0) {
+                html.push('<span class="filter-empty">no namespaced resources to filter</span>');
+            } else {
+                for (const ns of filterable) {
+                    const active = state.namespaces.has(ns) ? 'active' : '';
+                    html.push(`<button class="filter-btn ns-filter ${active}" data-value="${ns}">${ns}</button>`);
+                }
+            }
+            // Drop any selected namespaces that no longer exist in the
+            // new result set — keeps the URL clean and avoids zombie
+            // filters that would silently empty the table.
+            for (const ns of [...state.namespaces]) {
+                if (!namespaces.includes(ns)) state.namespaces.delete(ns);
+            }
+            row.innerHTML = html.join('');
         }
     </script>
 </body>

--- a/web/templates/resources.html
+++ b/web/templates/resources.html
@@ -1,3 +1,8 @@
+{{/* Hidden data carrier — the kind-filtered namespace set as a
+JSON array. JS in index.html reads `data-namespaces` and rebuilds
+the namespace chip row, preserving the user's current selection. */}}
+<div id="ns-data" data-namespaces='[{{range $i, $ns := .Namespaces}}{{if $i}},{{end}}"{{$ns}}"{{end}}]' style="display:none"></div>
+
 {{if .Resources}}
 <div class="count">{{len .Resources}} resource{{if ne (len .Resources) 1}}s{{end}} found</div>
 <table class="resource-table">

--- a/web_test.go
+++ b/web_test.go
@@ -26,11 +26,22 @@ func TestWebIndex(t *testing.T) {
 		t.Errorf("expected 200, got %d", rr.Code)
 	}
 	body := rr.Body.String()
-	if !strings.Contains(body, "machinery") {
-		t.Error("expected 'machinery' in response body")
-	}
-	if !strings.Contains(body, "htmx") {
-		t.Error("expected 'htmx' in response body")
+	for _, want := range []string{
+		"machinery", "htmx",
+		// Multi-select filter scaffolding — the JS owns state, the
+		// chips just need the right hooks. If any of these go missing
+		// the click handler stops binding and filtering breaks
+		// silently in the browser.
+		`id="kind-filters"`,
+		`id="namespace-filters"`,
+		`data-value="*"`,
+		// Stale-response guard for the auto-refresh poll.
+		`hx-sync="this:abort"`,
+		`filterChange`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("expected %q in index body", want)
+		}
 	}
 }
 
@@ -132,6 +143,109 @@ func TestWebNotFound(t *testing.T) {
 	if rr.Code != http.StatusNotFound {
 		t.Errorf("expected 404, got %d", rr.Code)
 	}
+}
+
+func TestWebResourcesNamespaceFilter(t *testing.T) {
+	mkVM := func(name, ns string) runtime.Object {
+		obj := &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "resources.stuttgart-things.com/v1alpha1",
+				"kind":       "HarvesterVM",
+				"metadata":   map[string]any{"name": name, "namespace": ns},
+				"status": map[string]any{
+					"conditions": []any{map[string]any{"type": "Ready", "status": "True"}},
+					"vm":         map[string]any{"name": name},
+				},
+			},
+		}
+		obj.SetGroupVersionKind(schema.GroupVersionKind{
+			Group: "resources.stuttgart-things.com", Version: "v1alpha1", Kind: "HarvesterVM",
+		})
+		return obj
+	}
+
+	srv := newTestServer(mkVM("vm-a", "team-a"), mkVM("vm-b", "team-b"), mkVM("vm-c", "team-a"))
+	webSrv, err := newWebServer(srv)
+	if err != nil {
+		t.Fatalf("failed to create web server: %v", err)
+	}
+
+	t.Run("no filter returns all", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/resources?kind=HarvesterVM", nil)
+		rr := httptest.NewRecorder()
+		webSrv.handler().ServeHTTP(rr, req)
+		body := rr.Body.String()
+		for _, name := range []string{"vm-a", "vm-b", "vm-c"} {
+			if !strings.Contains(body, name) {
+				t.Errorf("expected %s in response", name)
+			}
+		}
+	})
+
+	t.Run("single namespace narrows result", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/resources?kind=HarvesterVM&namespace=team-a", nil)
+		rr := httptest.NewRecorder()
+		webSrv.handler().ServeHTTP(rr, req)
+		body := rr.Body.String()
+		if !strings.Contains(body, "vm-a") || !strings.Contains(body, "vm-c") {
+			t.Error("expected vm-a and vm-c (both in team-a)")
+		}
+		if strings.Contains(body, "vm-b") {
+			t.Error("did not expect vm-b (in team-b)")
+		}
+	})
+
+	t.Run("multi-namespace via CSV", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/resources?kind=HarvesterVM&namespace=team-a,team-b", nil)
+		rr := httptest.NewRecorder()
+		webSrv.handler().ServeHTTP(rr, req)
+		body := rr.Body.String()
+		for _, name := range []string{"vm-a", "vm-b", "vm-c"} {
+			if !strings.Contains(body, name) {
+				t.Errorf("expected %s in response", name)
+			}
+		}
+	})
+
+	t.Run("ns-data metadata lists both namespaces sorted", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/resources?kind=HarvesterVM&namespace=team-a", nil)
+		rr := httptest.NewRecorder()
+		webSrv.handler().ServeHTTP(rr, req)
+		body := rr.Body.String()
+		// The metadata div must enumerate ALL namespaces in the kind-
+		// filtered set, not just the ones surviving the namespace
+		// filter — otherwise the chip row collapses to the active set
+		// and users can't deselect.
+		if !strings.Contains(body, `data-namespaces='["team-a","team-b"]'`) {
+			t.Errorf("expected pre-filter ns metadata in response, got body:\n%s", body)
+		}
+	})
+
+	t.Run("cluster-scoped resources bypass namespace filter", func(t *testing.T) {
+		clusterObj := &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "resources.stuttgart-things.com/v1alpha1",
+				"kind":       "HarvesterVM",
+				"metadata":   map[string]any{"name": "cluster-scoped"},
+				"status": map[string]any{
+					"conditions": []any{map[string]any{"type": "Ready", "status": "True"}},
+				},
+			},
+		}
+		clusterObj.SetGroupVersionKind(schema.GroupVersionKind{
+			Group: "resources.stuttgart-things.com", Version: "v1alpha1", Kind: "HarvesterVM",
+		})
+		srv2 := newTestServer(mkVM("vm-a", "team-a"), clusterObj)
+		webSrv2, _ := newWebServer(srv2)
+
+		req := httptest.NewRequest("GET", "/resources?kind=HarvesterVM&namespace=team-a", nil)
+		rr := httptest.NewRecorder()
+		webSrv2.handler().ServeHTTP(rr, req)
+		body := rr.Body.String()
+		if !strings.Contains(body, "cluster-scoped") {
+			t.Error("expected cluster-scoped resource to bypass the namespace filter")
+		}
+	})
 }
 
 // Ensure unused import is used


### PR DESCRIPTION
## Summary
Three UI fixes surfaced on the `machinery-pr-64` preview env, all in one PR.

### 1. Stale-poll race
Picking a new kind sometimes left old rows in the table — the every-5s auto-refresh could finish **after** a filter-click request and overwrite the fresh response. Added `hx-sync="this:abort"` on `#resource-list` so any in-flight request gets cancelled when a new one starts; both the click and the timer go through a single `filterChange` event.

### 2. Multi-select kind filter
Backend already accepted comma-separated kinds (`main.go:142-145`); only the UI was single-select. Chips now toggle membership in a JS `Set`, and "All" deselects everything. URL is rebuilt on every change.

### 3. Namespace filter
Added a second chip row populated dynamically from each response. Server emits the sorted unique namespace set as a hidden `data-namespaces` JSON attribute on the resource partial; JS rebuilds the chip row on `htmx:afterSwap`, preserving the active selection.

Decision notes worth flagging:
- **Filter applies web-side, not gRPC-side.** Keeps `GetResources` protocol-stable for the gRPC client.
- **Metadata is the pre-filter set, not the post-filter set.** Otherwise the chip row would collapse to "only what's currently selected" and you couldn't deselect.
- **Cluster-scoped resources bypass the namespace filter.** No useful chip to render for `Namespace==""`, and silently dropping them would surprise users mixing scopes. Documented inline + covered by a test.

## Test plan
- [x] `go test -race ./...` — new sub-tests for single-ns narrowing, CSV multi-ns, pre-filter metadata, cluster-scoped bypass, and that the rendered index contains the JS hooks (`id="kind-filters"`, `hx-sync="this:abort"`, `filterChange`)
- [x] `go vet ./...` clean
- [ ] Preview env spun up by this PR (`preview` label attached) — click around: toggle multiple kinds, narrow by namespace, confirm switching filters mid-poll never shows stale rows
- [ ] On a cluster with cluster-scoped CRDs in the watch set, confirm those rows stay visible regardless of namespace selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)