### PR TITLE
fix: tolerate per-kind 404s in GetResources, bump ExternalSecret example to v1

### DIFF
--- a/examples/configs/gateway-api.json
+++ b/examples/configs/gateway-api.json
@@ -17,7 +17,7 @@
     },
     "ExternalSecret": {
       "group": "external-secrets.io",
-      "version": "v1beta1",
+      "version": "v1",
       "resource": "externalsecrets",
       "connectionField": "status.refreshTime",
       "statusFields": ["status.syncedResourceVersion"],

--- a/main.go
+++ b/main.go
@@ -20,6 +20,8 @@ import (
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/status"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/dynamic"
@@ -164,6 +166,15 @@ func (s *server) GetResources(ctx context.Context, req *resourceservice.Resource
 
 		resourceList, err := s.dynamicClient.Resource(gvr).List(ctx, metav1.ListOptions{})
 		if err != nil {
+			// Skip kinds the API server no longer serves (CRD removed,
+			// API version retired, beta graduated to stable, …). One
+			// broken kind shouldn't blank the dashboard for kinds that
+			// do work — log loudly so operators can spot config drift.
+			if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
+				slog.Warn("kind not available on cluster, skipping",
+					"kind", kind, "gvr", gvr.String(), "error", err)
+				continue
+			}
 			return nil, fmt.Errorf("error fetching resources for kind %s: %w", kind, err)
 		}
 

--- a/main_test.go
+++ b/main_test.go
@@ -9,10 +9,12 @@ import (
 	resourceservice "github.com/stuttgart-things/maschinist/resourceservice"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
+	clienttesting "k8s.io/client-go/testing"
 )
 
 var testListKinds = map[schema.GroupVersionResource]string{
@@ -27,6 +29,91 @@ func newTestServer(objects ...runtime.Object) *server {
 	return &server{
 		dynamicClient: fakeClient,
 		config:        defaultConfig(),
+	}
+}
+
+// newTestServerWithMissingKind builds a server whose fake dynamic
+// client knows the given GVR (so it doesn't panic on a List call)
+// but a reactor intercepts that List and returns NotFound — the
+// same response shape the real API server uses when a CRD is gone
+// or a beta API version has been retired. The fake's "kind is
+// registered with customListKinds" check runs *before* reactors,
+// so the GVR has to be in the kind map for the reactor to even
+// get a chance.
+func newTestServerWithMissingKind(missing schema.GroupVersionResource, listKind string, objects ...runtime.Object) *server {
+	scheme := runtime.NewScheme()
+	kinds := map[schema.GroupVersionResource]string{}
+	for k, v := range testListKinds {
+		kinds[k] = v
+	}
+	kinds[missing] = listKind
+	fakeClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, kinds, objects...)
+	fakeClient.PrependReactor("list", missing.Resource, func(action clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewNotFound(schema.GroupResource{Group: missing.Group, Resource: missing.Resource}, "")
+	})
+	return &server{dynamicClient: fakeClient, config: defaultConfig()}
+}
+
+func TestGetResources_SkipsKindsMissingFromCluster(t *testing.T) {
+	vm := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "resources.stuttgart-things.com/v1alpha1",
+			"kind":       "HarvesterVM",
+			"metadata":   map[string]any{"name": "vm-still-here", "namespace": "default"},
+			"status": map[string]any{
+				"conditions": []any{map[string]any{"type": "Ready", "status": "True"}},
+				"vm":         map[string]any{"name": "vm-still-here"},
+			},
+		},
+	}
+	vm.SetGroupVersionKind(schema.GroupVersionKind{
+		Group: "resources.stuttgart-things.com", Version: "v1alpha1", Kind: "HarvesterVM",
+	})
+
+	// One healthy kind from defaultConfig, plus an additional kind
+	// the (simulated) cluster doesn't serve. With the resilience fix
+	// the call should succeed and just drop the broken kind.
+	missing := schema.GroupVersionResource{Group: "example.com", Version: "v1beta1", Resource: "gonefromclusters"}
+	s := newTestServerWithMissingKind(missing, "GoneFromClusterList", vm)
+	s.config.Resources["GoneFromCluster"] = ResourceKind{
+		Group: missing.Group, Version: missing.Version, Resource: missing.Resource,
+	}
+
+	resp, err := s.GetResources(context.Background(), &resourceservice.ResourceRequest{
+		Kind:  "*",
+		Count: -1,
+	})
+	if err != nil {
+		t.Fatalf("expected nil error (broken kind should be skipped), got %v", err)
+	}
+	if len(resp.Resources) != 1 || resp.Resources[0].Name != "vm-still-here" {
+		t.Fatalf("expected one resource from the healthy kind, got %+v", resp.Resources)
+	}
+	if resp.Resources[0].Kind != "HarvesterVM" {
+		t.Errorf("expected Kind=HarvesterVM, got %q", resp.Resources[0].Kind)
+	}
+}
+
+func TestGetResources_AllKindsMissingReturnsEmpty(t *testing.T) {
+	// Edge case: every configured kind is missing → no error, empty
+	// list. The dashboard shows the "No resources found" empty state
+	// instead of an HTTP 500. Failing loudly here would only make
+	// every fresh install with a stale config look broken.
+	missing := schema.GroupVersionResource{Group: "example.com", Version: "v1beta1", Resource: "onlygonekinds"}
+	s := newTestServerWithMissingKind(missing, "OnlyGoneKindList")
+	s.config.Resources = map[string]ResourceKind{
+		"OnlyGoneKind": {Group: missing.Group, Version: missing.Version, Resource: missing.Resource},
+	}
+
+	resp, err := s.GetResources(context.Background(), &resourceservice.ResourceRequest{
+		Kind:  "*",
+		Count: -1,
+	})
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if len(resp.Resources) != 0 {
+		t.Errorf("expected empty result, got %d resources", len(resp.Resources))
 	}
 }
 


### PR DESCRIPTION
## Summary
One broken kind currently blanks the whole dashboard. `GetResources` returns an error from its first failing kind, the web handler responds HTTP 500, and the table stays empty for every kind — including the ones that would have returned data fine.

Surfaced on `machinery-pr-65`: External Secrets Operator graduated to `v1` and stopped serving `v1beta1` on `homerun2-dev`, the preview AppSet's config still asked for `v1beta1`, machinery 404'd. Certificate + HTTPRoute rows were collateral damage. Fixed argocd-side in [stuttgart-things/argocd#159](https://github.com/stuttgart-things/argocd/pull/159), but the underlying brittleness should also live in machinery so future API-graduation drift doesn't take the UI down again.

## Changes
- `main.go` — when the API returns `IsNotFound` (or the REST mapper raises `NoMatchError`), log a warning naming the kind + GVR and skip just that kind. Other kinds keep going. Other errors still fail loud.
- `examples/configs/gateway-api.json` — `v1beta1` → `v1` for ExternalSecret, matching what ESO actually serves now.
- `main_test.go`:
  - `TestGetResources_SkipsKindsMissingFromCluster` — mixed valid/invalid kinds, healthy result still comes through.
  - `TestGetResources_AllKindsMissingReturnsEmpty` — everything broken, expect empty (not error).
  - New helper `newTestServerWithMissingKind` — registers the GVR with the fake's listKinds map (otherwise the fake panics before reactors can run) and a `PrependReactor` returns `NotFound` on the List call.

## Test plan
- [x] `go test -race ./...` green
- [x] `go vet ./...` clean
- [ ] Preview env: after this PR's image lands and `machinery-pr-66` (or whatever number) spins up, intentionally configure one broken kind and confirm the dashboard renders the others (preview AppSet's bump to v1 from argocd#159 makes this a synthetic test — the real-world resilience is what we want)

🤖 Generated with [Claude Code](https://claude.com/claude-code)