### PR TITLE
docs(ci): preview troubleshooting + fix multi-filter click handler

### DIFF
--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -115,3 +115,36 @@ own once the PR drops out of the generator's result set.
 3. Apply the `preview` label.
 4. A PR comment with the live URL shows up shortly after Argo syncs.
 5. Close (or merge) the PR to tear everything down.
+
+## Troubleshooting
+
+If the preview URL responds `HTTP 500` from `server: envoy` with
+no inbound request lines on the pod, the HTTPRoute is the suspect
+rather than machinery itself. Check `ResolvedRefs`:
+
+```
+kubectl -n machinery-pr-<num> get httproute machinery -o yaml \
+  | yq '.status.parents[].conditions[] | select(.type=="ResolvedRefs")'
+```
+
+A `BackendNotFound` here with a stale `lastTransitionTime` means
+Cilium's gateway-controller latched the verdict before the backend
+Service made it into its informer cache. The
+`apps/machinery/httproute` chart in `stuttgart-things/argocd` ships
+a PostSync `Job` that re-annotates the HTTPRoute on every sync to
+force Cilium to re-reconcile — if that Job ran successfully, the
+race is already self-healed. Set
+`httpRoute.nudgeAfterSync: false` on the install chart's values to
+opt out of the Job (sensible only for long-lived deployments where
+the gateway-controller's cache is steady-state).
+
+If the dashboard renders but the resource table stays empty for
+**every** kind, `kubectl logs deploy/machinery` will usually show
+the cause directly — typically `the server could not find the
+requested resource` against a CRD that's been removed or an API
+version that has been retired (e.g. ESO `v1beta1` → `v1`).
+`GetResources` skips any kind that 404s and continues with the
+others, so a single broken kind only loses its own rows. RBAC
+gaps surface the same way but as `forbidden`; the
+`apps/machinery/install` chart's `rbac.rules` block controls the
+ClusterRole the machinery SA gets.

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -308,12 +308,19 @@
 
         function refreshNow() {
             const list = document.getElementById('resource-list');
-            list.setAttribute('hx-get', buildURL());
-            // `filterChange` is one of the hx-trigger events on the
-            // list; firing it kicks off a fresh request. The element's
-            // hx-sync="this:abort" cancels any in-flight every-5s poll
-            // so a stale response can't overwrite the new one.
-            htmx.trigger(list, 'filterChange');
+            const url = buildURL();
+            // Keep hx-get in sync so the every-5s poller picks up the
+            // new URL on its next tick.
+            list.setAttribute('hx-get', url);
+            // Drive the request directly. `htmx.trigger(elt, 'event')`
+            // dispatches a CustomEvent but live tests on
+            // machinery-pr-67 showed it doesn't reliably re-fire the
+            // request when combined with `every 5s` polling on the
+            // same element — clicks updated the active class but the
+            // table stayed on the previous response. `htmx.ajax` is
+            // unambiguous and still respects hx-sync="this:abort", so
+            // a stale poll can't overwrite the fresh response either.
+            htmx.ajax('GET', url, '#resource-list');
         }
 
         function syncAllButton(rowId, set) {


### PR DESCRIPTION
## Summary
Doubles as the end-of-day smoke test for the full preview-app stack: every fix that landed today (Cilium nudge hook, image registry swap, ExternalSecret v1, per-kind 404 resilience) should mean this PR's preview env comes up healthy on first sync, no manual `kubectl annotate`, and the dashboard table populates with the real Certificate / ExternalSecret / HTTPRoute rows from `homerun2-dev`.

Adds a small **Troubleshooting** section to `docs/ci-cd.md` covering the two failure modes that surfaced today and weren't obvious from the existing docs:
- Envoy `500` with no pod traffic → check `ResolvedRefs`; the PostSync nudge hook auto-resolves it.
- Dashboard renders but every row is empty → check pod logs for `the server could not find the requested resource`; `GetResources` now skips per-kind 404s, so a single broken kind is local damage rather than a full blackout.

## Acceptance
- [ ] CI green
- [ ] `machinery-pr-<n>` env spins up
- [ ] **No** manual nudge required (`curl /health` returns `200` on first try)
- [ ] Dashboard table shows rows for all three kinds (Certificate / ExternalSecret / HTTPRoute)

🤖 Generated with [Claude Code](https://claude.com/claude-code)