### PR TITLE
feat(kcl): GRPCRoute for in-cluster gRPC access

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ kcl run kcl/main.k -Y tests/kcl-deploy-profile.yaml
 kcl run kcl/main.k -Y tests/kcl-deploy-profile.yaml | kubectl apply -f -
 ```
 
-Features: gRPC/HTTP health probes, hardened security context (non-root, read-only rootfs, drop all capabilities), pod anti-affinity, optional kubeconfig secret mount, Gateway API HTTPRoute.
+Features: gRPC/HTTP health probes, hardened security context (non-root, read-only rootfs, drop all capabilities), pod anti-affinity, optional kubeconfig secret mount, Gateway API HTTPRoute and GRPCRoute (opt-in, see [`kcl/README.md`](kcl/README.md) for the gRPC-via-gateway profile).
 
 See [`kcl/README.md`](kcl/README.md) for all configuration options and manifest structure.
 

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -138,6 +138,16 @@ race is already self-healed. Set
 opt out of the Job (sensible only for long-lived deployments where
 the gateway-controller's cache is steady-state).
 
+Preview envs also expose the gRPC service through the same gateway
+via a sibling `GRPCRoute` (`machinery-pr-<num>-grpc.…`), driven by
+the `apps/machinery/grpcroute` sub-chart in `stuttgart-things/argocd`.
+The Cilium race above hits `GRPCRoute`s identically (same controller,
+same informer-cache ordering), so the sub-chart ships an analogous
+PostSync nudge — same `nudgeAfterSync` opt-out under the `grpcRoute:`
+values block. Verify the route the same way (swap `httproute` →
+`grpcroute` in the kubectl call) and call it with `grpcurl` against
+the gRPC hostname on port 443 (TLS terminates at the gateway).
+
 If the dashboard renders but the resource table stays empty for
 **every** kind, `kubectl logs deploy/machinery` will usually show
 the cause directly — typically `the server could not find the

--- a/kcl/README.md
+++ b/kcl/README.md
@@ -24,6 +24,7 @@ kcl run kcl/main.k -Y tests/kcl-deploy-profile.yaml | yq eval '.manifests[] | sp
 | `deploy.k` | Deployment with health probes, security context |
 | `service.k` | ClusterIP service (gRPC + optional HTTP) |
 | `httproute.k` | Gateway API HTTPRoute (optional) |
+| `grpcroute.k` | Gateway API GRPCRoute (optional) |
 | `configmap.k` | ConfigMap for environment variables |
 | `namespace.k` | Namespace |
 | `serviceaccount.k` | ServiceAccount |
@@ -49,3 +50,36 @@ kcl_options:
 ```
 
 See `schema.k` for all available options and defaults.
+
+## gRPC via the Gateway (in-cluster / local-network)
+
+Expose the gRPC `ResourceService` through the same Gateway as the HTMX UI by
+enabling a `GRPCRoute`. `parentRefName`/`parentRefNamespace` default to the
+HTTPRoute values when unset, so most profiles only need the enable flag:
+
+```yaml
+kcl_options:
+  - key: config.grpcRouteEnabled
+    value: True
+  # optional — defaults to httpRouteParentRefName / httpRouteParentRefNamespace
+  - key: config.grpcRouteParentRefName
+    value: movie-scripts2-gateway
+  - key: config.grpcRouteParentRefNamespace
+    value: default
+  - key: config.grpcRouteHostname
+    value: machinery-grpc.example.com
+```
+
+Then dial through the Gateway:
+
+```bash
+# health check
+grpcurl -plaintext machinery-grpc.example.com:80 grpc.health.v1.Health/Check
+
+# via the bundled client
+CLUSTERBOOK_SERVER=machinery-grpc.example.com:80 SECURE_CONNECTION=false \
+  go run client/client.go
+```
+
+> Scoped to local-network access; no TLS or auth is added here — track those
+> separately.

--- a/kcl/grpcroute.k
+++ b/kcl/grpcroute.k
@@ -1,0 +1,47 @@
+"""
+GRPCRoute (Gateway API) for machinery
+"""
+
+import labels
+
+config = labels.config
+
+_hostname = config.grpcRouteHostname
+_parentRefName = config.grpcRouteParentRefName or config.httpRouteParentRefName
+_parentRefNamespace = config.grpcRouteParentRefNamespace or config.httpRouteParentRefNamespace
+
+grpcroute = {
+    apiVersion: "gateway.networking.k8s.io/v1"
+    kind: "GRPCRoute"
+    metadata: {
+        name: config.name
+        namespace: config.namespace
+        labels: labels.commonLabels
+        if config.annotations or config.grpcRouteAnnotations:
+            annotations: {
+                **config.annotations
+                **config.grpcRouteAnnotations
+            }
+    }
+    spec: {
+        parentRefs: [
+            {
+                name: _parentRefName
+                if _parentRefNamespace:
+                    namespace: _parentRefNamespace
+            }
+        ]
+        if _hostname:
+            hostnames: [_hostname]
+        rules: [
+            {
+                backendRefs: [
+                    {
+                        name: config.name
+                        port: config.grpcPort
+                    }
+                ]
+            }
+        ]
+    }
+} if config.grpcRouteEnabled else None

--- a/kcl/labels.k
+++ b/kcl/labels.k
@@ -17,6 +17,11 @@ _httpRouteParentRefName = option("config.httpRouteParentRefName")
 _httpRouteParentRefNamespace = option("config.httpRouteParentRefNamespace")
 _httpRouteHostname = option("config.httpRouteHostname")
 _httpRouteAnnotations = option("config.httpRouteAnnotations") or {}
+_grpcRouteEnabled = option("config.grpcRouteEnabled")
+_grpcRouteParentRefName = option("config.grpcRouteParentRefName")
+_grpcRouteParentRefNamespace = option("config.grpcRouteParentRefNamespace")
+_grpcRouteHostname = option("config.grpcRouteHostname")
+_grpcRouteAnnotations = option("config.grpcRouteAnnotations") or {}
 _extraEnvVars = option("config.extraEnvVars") or {}
 
 # Config instance with command-line overrides
@@ -45,6 +50,16 @@ config: schema.Machinery = schema.Machinery {
         httpRouteHostname = _httpRouteHostname
     if _httpRouteAnnotations:
         httpRouteAnnotations = _httpRouteAnnotations
+    if _grpcRouteEnabled:
+        grpcRouteEnabled = _grpcRouteEnabled in [True, "True", "true"]
+    if _grpcRouteParentRefName:
+        grpcRouteParentRefName = _grpcRouteParentRefName
+    if _grpcRouteParentRefNamespace:
+        grpcRouteParentRefNamespace = _grpcRouteParentRefNamespace
+    if _grpcRouteHostname:
+        grpcRouteHostname = _grpcRouteHostname
+    if _grpcRouteAnnotations:
+        grpcRouteAnnotations = _grpcRouteAnnotations
     if _extraEnvVars:
         extraEnvVars = _extraEnvVars
 }

--- a/kcl/main.k
+++ b/kcl/main.k
@@ -9,6 +9,7 @@ import configmap
 import deploy
 import service
 import httproute
+import grpcroute
 
 # Export all manifests (filter out None values)
 manifests = [
@@ -20,5 +21,6 @@ manifests = [
         deploy.deployment
         service.service
         httproute.httproute
+        grpcroute.grpcroute
     ] if m
 ]

--- a/kcl/schema.k
+++ b/kcl/schema.k
@@ -37,6 +37,13 @@ schema Machinery:
     httpRouteHostname: str = ""
     httpRouteAnnotations: {str:str} = {}
 
+    # GRPCRoute (Gateway API)
+    grpcRouteEnabled: bool = False
+    grpcRouteParentRefName: str = ""
+    grpcRouteParentRefNamespace: str = ""
+    grpcRouteHostname: str = ""
+    grpcRouteAnnotations: {str:str} = {}
+
     # Kubeconfig
     kubeconfigSecret: str = ""
 


### PR DESCRIPTION
## Summary
- Adds `kcl/grpcroute.k`, a sibling to `httproute.k`, rendering a Gateway API `GRPCRoute` that points at the Service's `grpc` port.
- New schema fields on `Machinery`: `grpcRouteEnabled` (default `False`), `grpcRouteParentRefName`/`grpcRouteParentRefNamespace`, `grpcRouteHostname`, `grpcRouteAnnotations`. Parent-ref fields fall back to the HTTPRoute values when unset, so single-Gateway profiles only need the enable flag.
- Wires the new fields through `labels.k` `option()` overrides and includes the resource in `main.k`. Default render is unchanged when the flag is off.
- Documents enabling the route and dialing via `grpcurl` / `client/client.go` in `kcl/README.md`.

Closes #55.

## Test plan
- [x] `kcl run kcl/` with defaults: no `GRPCRoute` and no `HTTPRoute` rendered (baseline unchanged).
- [x] `kcl run kcl/ -D config.grpcRouteEnabled=True -D config.grpcRouteParentRefName=... -D config.grpcRouteHostname=...`: emits a valid `gateway.networking.k8s.io/v1` `GRPCRoute` with `backendRefs[0].port == config.grpcPort` (50051).
- [x] `kcl run kcl/ -D config.grpcRouteEnabled=True -D config.httpRouteParentRefName=shared-gateway -D config.httpRouteParentRefNamespace=infra`: `GRPCRoute` reuses the HTTPRoute parentRef when no grpc-specific one is set.
- [ ] On a cluster with Cilium Gateway API: `grpcurl -plaintext <gateway>:<port> grpc.health.v1.Health/Check` returns `SERVING`.
- [ ] `client/client.go` against the Gateway address returns resources end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)