### PR TITLE
feat(auth): bearer-token gRPC interceptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,32 @@ Resource types are configurable via JSON. Set `MACHINERY_CONFIG` to load a custo
 |----------|-------------|---------|
 | `KUBECONFIG` | Path to kubeconfig file | in-cluster config |
 | `MACHINERY_CONFIG` | Path to JSON config file | built-in defaults |
+| `MACHINERY_AUTH_TOKEN` | Bearer token for the gRPC `auth` gate (see below); also picked up by `client/client.go` | unset |
+
+### gRPC auth (opt-in)
+
+The gRPC `ResourceService` runs anonymous by default — appropriate for in-cluster usage where access is gated at the network/Gateway layer. To require a bearer token on every network-side RPC, set:
+
+```json
+{
+  "auth": {
+    "enabled": true,
+    "tokenFile": "/etc/machinery/auth-token"
+  }
+}
+```
+
+Token resolution order: `auth.token` (inline) → `auth.tokenFile` → `$auth.tokenEnvVar` → `$MACHINERY_AUTH_TOKEN`. Startup fails fast if `enabled: true` but no token resolves. `/grpc.health.v1.Health/*` stays anonymous so liveness/readiness probes keep working. In-process calls from the HTMX frontend (`web.go`) bypass the interceptor by construction. Pair this with the GRPCRoute (see [`kcl/README.md`](kcl/README.md)) when exposing the service beyond the pod network.
+
+Caller side:
+
+```bash
+grpcurl -H 'authorization: Bearer <token>' \
+  -authority machinery-grpc.example.com \
+  machinery-grpc.example.com:443 resourceservice.ResourceService/GetResources
+```
+
+or via `client/client.go`: `MACHINERY_AUTH_TOKEN=<token> go run client/client.go`.
 
 ### Config File
 

--- a/auth.go
+++ b/auth.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"context"
+	"crypto/subtle"
+	"fmt"
+	"os"
+	"strings"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	defaultAuthTokenEnvVar = "MACHINERY_AUTH_TOKEN"
+	healthServicePrefix    = "/grpc.health.v1.Health/"
+)
+
+// resolveAuthToken returns the token machinery should accept on the gRPC
+// network path. Order: inline cfg.Token → cfg.TokenFile contents →
+// $cfg.TokenEnvVar → $MACHINERY_AUTH_TOKEN. Whitespace is trimmed.
+// Returns ("", nil) when no token is configured anywhere — callers
+// decide whether that is fatal (it is when AuthConfig.Enabled is true).
+func resolveAuthToken(cfg AuthConfig) (string, error) {
+	if cfg.Token != "" {
+		return strings.TrimSpace(cfg.Token), nil
+	}
+	if cfg.TokenFile != "" {
+		data, err := os.ReadFile(cfg.TokenFile)
+		if err != nil {
+			return "", fmt.Errorf("reading auth token file %q: %w", cfg.TokenFile, err)
+		}
+		return strings.TrimSpace(string(data)), nil
+	}
+	if cfg.TokenEnvVar != "" {
+		if v := strings.TrimSpace(os.Getenv(cfg.TokenEnvVar)); v != "" {
+			return v, nil
+		}
+	}
+	if v := strings.TrimSpace(os.Getenv(defaultAuthTokenEnvVar)); v != "" {
+		return v, nil
+	}
+	return "", nil
+}
+
+// newAuthInterceptor returns a UnaryServerInterceptor that requires
+// `authorization: Bearer <token>` metadata on every RPC except those
+// under /grpc.health.v1.Health/ (LB/k8s probes stay anonymous).
+// The expected token is captured at construction time, so callers can
+// keep it out of long-lived globals.
+func newAuthInterceptor(expected string) grpc.UnaryServerInterceptor {
+	expectedBytes := []byte(expected)
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		if strings.HasPrefix(info.FullMethod, healthServicePrefix) {
+			return handler(ctx, req)
+		}
+		md, ok := metadata.FromIncomingContext(ctx)
+		if !ok {
+			return nil, status.Error(codes.Unauthenticated, "missing metadata")
+		}
+		values := md.Get("authorization")
+		if len(values) == 0 {
+			return nil, status.Error(codes.Unauthenticated, "missing authorization header")
+		}
+		// gRPC normalizes keys to lower-case but the scheme prefix is
+		// case-insensitive per RFC 6750; match either Bearer or bearer.
+		raw := values[0]
+		const prefix = "bearer "
+		if len(raw) <= len(prefix) || !strings.EqualFold(raw[:len(prefix)], prefix) {
+			return nil, status.Error(codes.Unauthenticated, "authorization scheme must be Bearer")
+		}
+		got := []byte(strings.TrimSpace(raw[len(prefix):]))
+		if subtle.ConstantTimeEq(int32(len(got)), int32(len(expectedBytes))) != 1 ||
+			subtle.ConstantTimeCompare(got, expectedBytes) != 1 {
+			return nil, status.Error(codes.Unauthenticated, "invalid token")
+		}
+		return handler(ctx, req)
+	}
+}

--- a/auth_test.go
+++ b/auth_test.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+const testToken = "s3cr3t-test-token"
+
+func okHandler(_ context.Context, _ any) (any, error) { return "ok", nil }
+
+func TestAuthInterceptor_MissingMetadata_Unauthenticated(t *testing.T) {
+	interceptor := newAuthInterceptor(testToken)
+	_, err := interceptor(context.Background(), nil, &grpc.UnaryServerInfo{FullMethod: "/Foo/Bar"}, okHandler)
+	if got := status.Code(err); got != codes.Unauthenticated {
+		t.Fatalf("got code %v, want Unauthenticated; err=%v", got, err)
+	}
+}
+
+func TestAuthInterceptor_MissingHeader_Unauthenticated(t *testing.T) {
+	interceptor := newAuthInterceptor(testToken)
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-other", "value"))
+	_, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/Foo/Bar"}, okHandler)
+	if got := status.Code(err); got != codes.Unauthenticated {
+		t.Fatalf("got code %v, want Unauthenticated", got)
+	}
+}
+
+func TestAuthInterceptor_BadScheme_Unauthenticated(t *testing.T) {
+	interceptor := newAuthInterceptor(testToken)
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("authorization", "Basic "+testToken))
+	_, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/Foo/Bar"}, okHandler)
+	if got := status.Code(err); got != codes.Unauthenticated {
+		t.Fatalf("got code %v, want Unauthenticated", got)
+	}
+}
+
+func TestAuthInterceptor_BadToken_Unauthenticated(t *testing.T) {
+	interceptor := newAuthInterceptor(testToken)
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("authorization", "Bearer wrong-token"))
+	_, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/Foo/Bar"}, okHandler)
+	if got := status.Code(err); got != codes.Unauthenticated {
+		t.Fatalf("got code %v, want Unauthenticated", got)
+	}
+}
+
+func TestAuthInterceptor_ValidToken_PassesThrough(t *testing.T) {
+	for _, scheme := range []string{"Bearer ", "bearer "} {
+		t.Run(scheme, func(t *testing.T) {
+			interceptor := newAuthInterceptor(testToken)
+			ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("authorization", scheme+testToken))
+			resp, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/Foo/Bar"}, okHandler)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if resp != "ok" {
+				t.Fatalf("got resp %v, want ok", resp)
+			}
+		})
+	}
+}
+
+func TestAuthInterceptor_HealthExempt(t *testing.T) {
+	interceptor := newAuthInterceptor(testToken)
+	// No metadata at all; the health probe must still succeed.
+	resp, err := interceptor(context.Background(), nil, &grpc.UnaryServerInfo{FullMethod: "/grpc.health.v1.Health/Check"}, okHandler)
+	if err != nil {
+		t.Fatalf("health check should bypass auth, got error: %v", err)
+	}
+	if resp != "ok" {
+		t.Fatalf("got resp %v, want ok", resp)
+	}
+}
+
+func TestResolveAuthToken_Inline(t *testing.T) {
+	t.Setenv(defaultAuthTokenEnvVar, "")
+	got, err := resolveAuthToken(AuthConfig{Token: "  inline-token\n"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "inline-token" {
+		t.Fatalf("got %q, want %q", got, "inline-token")
+	}
+}
+
+func TestResolveAuthToken_FromFile(t *testing.T) {
+	t.Setenv(defaultAuthTokenEnvVar, "")
+	dir := t.TempDir()
+	path := filepath.Join(dir, "token")
+	if err := os.WriteFile(path, []byte("file-token\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := resolveAuthToken(AuthConfig{TokenFile: path})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "file-token" {
+		t.Fatalf("got %q, want %q", got, "file-token")
+	}
+}
+
+func TestResolveAuthToken_FromCustomEnv(t *testing.T) {
+	t.Setenv(defaultAuthTokenEnvVar, "")
+	t.Setenv("CUSTOM_AUTH_TOKEN", "env-token")
+	got, err := resolveAuthToken(AuthConfig{TokenEnvVar: "CUSTOM_AUTH_TOKEN"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "env-token" {
+		t.Fatalf("got %q, want %q", got, "env-token")
+	}
+}
+
+func TestResolveAuthToken_FromDefaultEnv(t *testing.T) {
+	t.Setenv(defaultAuthTokenEnvVar, "default-env-token")
+	got, err := resolveAuthToken(AuthConfig{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "default-env-token" {
+		t.Fatalf("got %q, want %q", got, "default-env-token")
+	}
+}
+
+func TestResolveAuthToken_Missing(t *testing.T) {
+	t.Setenv(defaultAuthTokenEnvVar, "")
+	got, err := resolveAuthToken(AuthConfig{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("got %q, want empty", got)
+	}
+}
+
+func TestResolveAuthToken_InlineBeatsEnv(t *testing.T) {
+	t.Setenv(defaultAuthTokenEnvVar, "env-token")
+	got, err := resolveAuthToken(AuthConfig{Token: "inline-token"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "inline-token" {
+		t.Fatalf("got %q, want inline-token (env should not override an inline token)", got)
+	}
+}

--- a/client/client.go
+++ b/client/client.go
@@ -15,15 +15,23 @@ import (
 )
 
 var (
-	secureConnection  = os.Getenv("SECURE_CONNECTION")  // "true" or "false"
-	clusterBookServer = os.Getenv("CLUSTERBOOK_SERVER") // localhost:50051
-	tlsCACertPath     = os.Getenv("TLS_CA_CERT")        // optional: path to CA cert for verification
-	tlsSkipVerify     = os.Getenv("TLS_SKIP_VERIFY")    // "true" only for development
+	secureConnection  = os.Getenv("SECURE_CONNECTION")    // "true" or "false"
+	clusterBookServer = os.Getenv("CLUSTERBOOK_SERVER")   // localhost:50051
+	tlsCACertPath     = os.Getenv("TLS_CA_CERT")          // optional: path to CA cert for verification
+	tlsSkipVerify     = os.Getenv("TLS_SKIP_VERIFY")      // "true" only for development
+	authToken         = os.Getenv("MACHINERY_AUTH_TOKEN") // optional: bearer token; attached as `authorization: Bearer <token>` when set
 )
 
 func main() {
-	// Connect to the gRPC server
-	conn, err := grpc.NewClient(clusterBookServer, getCredentials())
+	dialOpts := []grpc.DialOption{getCredentials()}
+	if authToken != "" {
+		dialOpts = append(dialOpts, grpc.WithPerRPCCredentials(bearerToken{
+			token:    authToken,
+			insecure: secureConnection != "true",
+		}))
+	}
+
+	conn, err := grpc.NewClient(clusterBookServer, dialOpts...)
 	if err != nil {
 		log.Fatalf("Failed to connect to gRPC server: %v", err)
 	}
@@ -46,6 +54,23 @@ func main() {
 	for _, resource := range resp.Resources {
 		fmt.Printf("Name: %s, Kind: %s, Ready: %t, Status: %s, ConnectionDetails: %s\n", resource.Name, resource.Kind, resource.Ready, resource.StatusMessage, resource.ConnectionDetails)
 	}
+}
+
+// bearerToken implements grpc.PerRPCCredentials, attaching
+// `authorization: Bearer <token>` to every outgoing RPC. RequireTransportSecurity
+// is reported per-instance so the same struct works on TLS and plaintext dial
+// paths — flip insecure=true to allow sending the token without TLS (LAN/dev).
+type bearerToken struct {
+	token    string
+	insecure bool
+}
+
+func (b bearerToken) GetRequestMetadata(_ context.Context, _ ...string) (map[string]string, error) {
+	return map[string]string{"authorization": "Bearer " + b.token}, nil
+}
+
+func (b bearerToken) RequireTransportSecurity() bool {
+	return !b.insecure
 }
 
 func getCredentials() grpc.DialOption {

--- a/config.go
+++ b/config.go
@@ -23,9 +23,22 @@ type ResourceKind struct {
 }
 
 type Config struct {
-	Port     int                     `json:"port"`
-	HttpPort int                     `json:"httpPort"`
+	Port      int                     `json:"port"`
+	HttpPort  int                     `json:"httpPort"`
 	Resources map[string]ResourceKind `json:"resources"`
+	Auth      AuthConfig              `json:"auth,omitempty"`
+}
+
+// AuthConfig gates the gRPC server on a bearer token. In-process callers
+// (web.go) bypass it by construction — interceptors only fire on the
+// network path. Token resolution order at startup: Token → TokenFile →
+// $TokenEnvVar → $MACHINERY_AUTH_TOKEN. With Enabled true and no token
+// resolved, startup fails fast rather than running wide-open.
+type AuthConfig struct {
+	Enabled     bool   `json:"enabled,omitempty"`
+	Token       string `json:"token,omitempty"`       // inline; test/dev only
+	TokenFile   string `json:"tokenFile,omitempty"`   // path; mounted from Secret in prod
+	TokenEnvVar string `json:"tokenEnvVar,omitempty"` // env var name; defaults to MACHINERY_AUTH_TOKEN
 }
 
 func loadConfig(path string) (*Config, error) {

--- a/main.go
+++ b/main.go
@@ -81,7 +81,22 @@ func main() {
 
 	srv := &server{dynamicClient: dynamicClient, config: cfg}
 
-	s := grpc.NewServer()
+	var grpcOpts []grpc.ServerOption
+	if cfg.Auth.Enabled {
+		token, err := resolveAuthToken(cfg.Auth)
+		if err != nil {
+			slog.Error("failed to resolve auth token", "error", err)
+			os.Exit(1)
+		}
+		if token == "" {
+			slog.Error("auth enabled but no token resolved", "tokenFile", cfg.Auth.TokenFile, "tokenEnvVar", cfg.Auth.TokenEnvVar)
+			os.Exit(1)
+		}
+		grpcOpts = append(grpcOpts, grpc.UnaryInterceptor(newAuthInterceptor(token)))
+		slog.Info("gRPC auth enabled (bearer token)")
+	}
+
+	s := grpc.NewServer(grpcOpts...)
 	resourceservice.RegisterResourceServiceServer(s, srv)
 
 	healthServer := health.NewServer()


### PR DESCRIPTION
## Summary
Adds an opt-in `UnaryInterceptor` that gates the gRPC `ResourceService` on a bearer token. Default behavior is unchanged (auth disabled), so existing in-cluster/Gateway-fronted deployments keep working.

- **`auth.go`** — `newAuthInterceptor(expected)` rejects RPCs without `authorization: Bearer <token>` metadata (`codes.Unauthenticated`). Constant-time compare via `crypto/subtle`. \`/grpc.health.v1.Health/*\` is exempted so liveness/readiness probes keep working anonymously. Case-insensitive scheme match (\`Bearer\`/\`bearer\` both fine, per RFC 6750).
- **`config.go`** — new `AuthConfig` (`Enabled`, `Token`, `TokenFile`, `TokenEnvVar`) on `Config`. Resolution order at startup: inline `Token` → `TokenFile` contents → `$TokenEnvVar` → `$MACHINERY_AUTH_TOKEN` (zero-config default). Startup **fails fast** if `enabled: true` but no token resolves.
- **`main.go`** — interceptor only wired when `cfg.Auth.Enabled`; logs "gRPC auth enabled (bearer token)" once at startup.
- **`client/client.go`** — honors `MACHINERY_AUTH_TOKEN` via a small `grpc.PerRPCCredentials` impl that works on both TLS and insecure dial paths (LAN/dev).
- **`auth_test.go`** — 13 unit tests covering the interceptor (missing metadata, missing header, bad scheme, bad token, valid `Bearer`/`bearer`, `/grpc.health.v1.Health/Check` exempt) and the token resolver (inline / file / custom env / default env / missing / inline-beats-env precedence).
- **`README.md`** — new "gRPC auth (opt-in)" section with config snippet and `grpcurl -H 'authorization: Bearer …'` example.
- **In-process callers (\`web.go\`)** — unchanged. They call the server methods directly on the Go struct; interceptors fire only on the network path. (See issue #56 for the rationale.)

Closes #56 (Phase 1 — bearer token). mTLS stays a separate follow-up per the issue. KCL Secret-mount support (\`kcl/schema.k\` + \`kcl/deploy.k\` extension) will land in a sibling PR so the Go change here is reviewable on its own.

## Test plan
- [x] \`go build ./...\` clean.
- [x] \`go vet ./...\` clean.
- [x] \`go test ./...\` — all 13 new tests pass alongside the pre-existing suite.
- [x] Interceptor behavior verified per-case (Bearer/bearer accepted, Basic rejected, missing-metadata rejected, health exempt without any metadata).
- [x] Token resolver precedence verified: inline > file > custom env > \`MACHINERY_AUTH_TOKEN\`.
- [ ] End-to-end against a live deployment with \`auth.enabled: true\` + Secret-mounted token, calling via \`grpcurl\` through the GRPCRoute on homerun2-dev (deferred until the sibling KCL PR lands so the preview env can mount a token).

🤖 Generated with [Claude Code](https://claude.com/claude-code)