### PR TITLE
feat(kcl): Secret-mount auth token

### DIFF
--- a/kcl/README.md
+++ b/kcl/README.md
@@ -83,3 +83,68 @@ CLUSTERBOOK_SERVER=machinery-grpc.example.com:80 SECURE_CONNECTION=false \
 
 > Scoped to local-network access; no TLS or auth is added here — track those
 > separately.
+
+## gRPC auth (Secret-mounted bearer token)
+
+When exposing the gRPC service beyond the pod network, gate it with the bearer-token
+interceptor (machinery's `Config.Auth`). The KCL base mounts an externally-managed
+`Secret` containing the token; the user's `MACHINERY_CONFIG` (passed via `configJson`)
+then references the mounted file via `auth.tokenFile`.
+
+The Secret itself is materialized out-of-band — by ESO, Kyverno generate, a sealed
+secret, or plain `kubectl create secret generic`. The KCL base only mounts it.
+
+```bash
+# 1. Create the Secret out-of-band (any mechanism that lands a key called `token`):
+kubectl -n machinery create secret generic machinery-auth-token \
+  --from-literal=token="$(openssl rand -hex 32)"
+```
+
+```yaml
+# 2. Reference it in your KCL profile. Defaults are sensible — only the Secret
+#    name is required; the field defaults to mounting key `token` at
+#    `/var/run/machinery-auth/token` (deliberately under /var/run so it can't
+#    collide with the /etc/machinery configJson mount).
+kcl_options:
+  - key: config.authTokenSecret
+    value: machinery-auth-token
+  # optional overrides:
+  # - key: config.authTokenSecretKey
+  #   value: token
+  # - key: config.authTokenMountPath
+  #   value: /var/run/machinery-auth/token
+
+  # 3. Enable auth in MACHINERY_CONFIG and point tokenFile at the mount path:
+  - key: config.configJson
+    value: |
+      {
+        "port": 50051,
+        "auth": {
+          "enabled": true,
+          "tokenFile": "/var/run/machinery-auth/token"
+        },
+        "resources": { ... }
+      }
+```
+
+Verify from outside the cluster (through the `GRPCRoute` from the previous section):
+
+```bash
+TOKEN=$(kubectl -n machinery get secret machinery-auth-token -o jsonpath='{.data.token}' | base64 -d)
+
+# Without the token → Unauthenticated
+grpcurl -authority machinery-grpc.example.com \
+  machinery-grpc.example.com:443 \
+  resourceservice.ResourceService/GetResources
+# ERROR: Code: Unauthenticated, Message: missing authorization header
+
+# With the token → success
+grpcurl -H "authorization: Bearer ${TOKEN}" \
+  -authority machinery-grpc.example.com \
+  machinery-grpc.example.com:443 \
+  resourceservice.ResourceService/GetResources
+```
+
+The HTMX dashboard is unaffected — its calls are in-process and bypass the
+interceptor. `/grpc.health.v1.Health/*` also stays anonymous, so liveness/readiness
+probes keep working without the token.

--- a/kcl/deploy.k
+++ b/kcl/deploy.k
@@ -122,7 +122,14 @@ deployment = {
                                 mountPath: "/etc/machinery"
                                 readOnly: True
                             }
-                        ] if config.configJson else [])
+                        ] if config.configJson else []) + ([
+                            {
+                                name: "auth-token"
+                                mountPath: config.authTokenMountPath
+                                subPath: "token"
+                                readOnly: True
+                            }
+                        ] if config.authTokenSecret else [])
                     }
                 ]
                 securityContext: {
@@ -153,7 +160,20 @@ deployment = {
                             name: "{}-config-file".format(config.name)
                         }
                     }
-                ] if config.configJson else [])
+                ] if config.configJson else []) + ([
+                    {
+                        name: "auth-token"
+                        secret: {
+                            secretName: config.authTokenSecret
+                            items: [
+                                {
+                                    key: config.authTokenSecretKey
+                                    path: "token"
+                                }
+                            ]
+                        }
+                    }
+                ] if config.authTokenSecret else [])
                 affinity: {
                     podAntiAffinity: {
                         preferredDuringSchedulingIgnoredDuringExecution: [

--- a/kcl/labels.k
+++ b/kcl/labels.k
@@ -22,6 +22,9 @@ _grpcRouteParentRefName = option("config.grpcRouteParentRefName")
 _grpcRouteParentRefNamespace = option("config.grpcRouteParentRefNamespace")
 _grpcRouteHostname = option("config.grpcRouteHostname")
 _grpcRouteAnnotations = option("config.grpcRouteAnnotations") or {}
+_authTokenSecret = option("config.authTokenSecret")
+_authTokenSecretKey = option("config.authTokenSecretKey")
+_authTokenMountPath = option("config.authTokenMountPath")
 _extraEnvVars = option("config.extraEnvVars") or {}
 
 # Config instance with command-line overrides
@@ -60,6 +63,12 @@ config: schema.Machinery = schema.Machinery {
         grpcRouteHostname = _grpcRouteHostname
     if _grpcRouteAnnotations:
         grpcRouteAnnotations = _grpcRouteAnnotations
+    if _authTokenSecret:
+        authTokenSecret = _authTokenSecret
+    if _authTokenSecretKey:
+        authTokenSecretKey = _authTokenSecretKey
+    if _authTokenMountPath:
+        authTokenMountPath = _authTokenMountPath
     if _extraEnvVars:
         extraEnvVars = _extraEnvVars
 }

--- a/kcl/schema.k
+++ b/kcl/schema.k
@@ -47,6 +47,17 @@ schema Machinery:
     # Kubeconfig
     kubeconfigSecret: str = ""
 
+    # gRPC auth — mount a Secret carrying the bearer token machinery
+    # checks via its Config.Auth.tokenFile path. The Secret itself is
+    # materialized externally (ESO / Kyverno / kubectl create secret);
+    # this block only wires it into the Pod. Leave authTokenSecret
+    # empty to skip the mount entirely (default behavior unchanged).
+    # The user's MACHINERY_CONFIG / configJson is responsible for
+    # setting auth.enabled: true and auth.tokenFile to authTokenMountPath.
+    authTokenSecret: str = ""
+    authTokenSecretKey: str = "token"
+    authTokenMountPath: str = "/var/run/machinery-auth/token"
+
     # Config file
     configJson: str = ""
 


### PR DESCRIPTION
## Summary
Adds first-class KCL support for mounting an externally-managed \`Secret\` into the machinery Pod so production deployments stop putting the gRPC bearer token (machinery#56) in a ConfigMap. Default-off — existing renders are unchanged.

- **\`kcl/schema.k\`** — three new opt-in fields:
  - \`authTokenSecret: str = \"\"\` — Secret name in the same namespace
  - \`authTokenSecretKey: str = \"token\"\` — key in the Secret carrying the token bytes
  - \`authTokenMountPath: str = \"/var/run/machinery-auth/token\"\` — file path inside the pod
- **\`kcl/deploy.k\`** — when \`authTokenSecret\` is non-empty, adds:
  - a \`Secret\` volume \`auth-token\` with \`items: [{key: <authTokenSecretKey>, path: token}]\`
  - a read-only \`volumeMount\` at \`authTokenMountPath\` using \`subPath: token\` so only the single file is exposed (not the whole directory)
- **\`kcl/labels.k\`** — \`option(\"config.authTokenSecret\")\` etc. passthrough.
- **\`kcl/README.md\`** — new "gRPC auth (Secret-mounted bearer token)" section: \`kubectl create secret\` snippet → KCL profile snippet → \`configJson\` snippet → \`grpcurl\` verification (with and without token).

### Why \`/var/run/machinery-auth/token\` instead of \`/etc/machinery/auth-token\`?

The \`configJson\` ConfigMap already mounts at \`/etc/machinery\`. Subpath-mounting another file under that dir from a Secret would either silently fail or create a confusing overlap depending on container runtime. Putting the token under \`/var/run\` keeps the two mounts independent. Override the path on the KCL side if you want — the field is plumbed through.

### Token lifecycle

The Secret is materialized **out-of-band** — ESO, Kyverno generate, sealed secrets, plain \`kubectl create secret generic\`, etc. The KCL base only wires it into the Pod; rotation is whatever your secret materializer provides (Kubernetes Secret-mounted-as-file gets the new bytes from the kubelet automatically — no Pod restart needed if the file is re-read on each gRPC call, which the interceptor's expected-token capture-at-construction doesn't currently do; that's a follow-up if rotation-without-restart is needed).

Closes #70.

## Test plan
- [x] \`kcl run kcl/\` with defaults: byte-for-byte identical Deployment to main (\`diff\` over the rendered output confirms no diff).
- [x] \`kcl run kcl/ -D config.authTokenSecret=machinery-auth-token\`: emits a \`Secret\` volume \`auth-token\` referencing \`secretName: machinery-auth-token\` with the default \`token\` key, and a read-only volumeMount at \`/var/run/machinery-auth/token\` with \`subPath: token\`.
- [x] \`kcl run kcl/ -D config.authTokenSecret=my-secret -D config.authTokenSecretKey=bearer -D config.authTokenMountPath=/run/secrets/bearer\`: honors all three overrides as expected.
- [ ] Live test on a preview env (label a follow-up PR and override the appset's inline \`auth.token\` for that PR to switch to \`authTokenSecret\` instead): \`grpcurl\` with the right token returns resources, without the token returns \`Unauthenticated\`, and the token does **not** appear in any rendered ConfigMap.

## Follow-ups
- \`stuttgart-things/argocd\` overlay: switch \`apps/machinery/install\` from inline \`auth.token\` to a Secret-backed mount that uses these new KCL fields. Once that lands, the preview AppSet can stop inlining the token in its ConfigMap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)