### PR TITLE
feat(examples): gRPC consumer CLI demonstrating GRPCRoute access (#57)

### DIFF
--- a/examples/consumer/README.md
+++ b/examples/consumer/README.md
@@ -82,14 +82,12 @@ The proto is small enough that the no-code path is fast. Same gateway
 address, same token, ad-hoc requests:
 
 Machinery does **not** register the gRPC reflection service, so
-`grpcurl` needs the proto file to know the message shapes. Point it at
-the one in this repo (or a checkout of it):
+`grpcurl` needs an explicit `-proto` for every call. Point it at the
+proto in this repo (or a checkout of it):
 
 ```bash
-PROTO=$(git rev-parse --show-toplevel)/resourceservice/resource_service.proto
-
-# Health check — does the route reach a pod at all? (no proto needed)
-grpcurl machinery.example.com:443 grpc.health.v1.Health/Check
+REPO=$(git rev-parse --show-toplevel)
+PROTO=$REPO/resourceservice/resource_service.proto
 
 # List five VsphereVMAnsible resources.
 grpcurl \
@@ -108,9 +106,20 @@ grpcurl \
   resourceservice.ResourceService/GetResourceDetail
 ```
 
-The `grpc.health.v1.Health` service is registered without a `-proto`
-because `grpcurl` ships the health proto built in. Add `-plaintext` if
-you're hitting an in-cluster port-forward instead of the gateway.
+For the health check, `consumer health` is the easiest path — it has
+the health proto compiled in. If you'd rather stay in `grpcurl`, you
+need to feed it a copy of the upstream health proto (machinery
+doesn't expose reflection):
+
+```bash
+curl -fsSL -o /tmp/health.proto \
+  https://raw.githubusercontent.com/grpc/grpc-proto/master/grpc/health/v1/health.proto
+grpcurl -proto /tmp/health.proto \
+  machinery.example.com:443 grpc.health.v1.Health/Check
+```
+
+Add `-plaintext` if you're hitting an in-cluster port-forward rather
+than the gateway.
 
 ## JSON output
 

--- a/examples/consumer/README.md
+++ b/examples/consumer/README.md
@@ -1,0 +1,136 @@
+# Example gRPC consumer
+
+A small Go CLI that demonstrates how to call machinery from another
+process. It exists to answer the questions that don't fit in the proto
+file: how do I dial, how do I attach a bearer token, what does a
+`GetResourceDetail` response actually look like, how do I exercise the
+[`GRPCRoute`](../../kcl/grpcroute.k) from outside the cluster.
+
+`client/client.go` at the repo root is the minimal smoke test;
+**this** is the copy-from-me example.
+
+## Build
+
+```bash
+go build -o consumer ./examples/consumer
+```
+
+## Commands
+
+| Command  | RPC                                       | Notes |
+|----------|-------------------------------------------|---|
+| `list`   | `ResourceService.GetResources`            | `--kind=*` returns every configured kind |
+| `get`    | `ResourceService.GetResourceDetail`       | `--kind` + `--name` required; `--namespace` for namespaced CRs |
+| `health` | `grpc.health.v1.Health/Check`             | non-zero exit if the server isn't `SERVING` |
+
+Connection flags accepted on **every** subcommand:
+
+| Flag                | Env                          | Default            | Purpose |
+|---------------------|------------------------------|--------------------|---|
+| `--server`          | `MACHINERY_SERVER`           | `localhost:50051`  | host:port of the gRPC endpoint |
+| `--insecure`        | `MACHINERY_INSECURE`         | `true`             | plaintext gRPC; flip for TLS |
+| `--ca-cert`         | `MACHINERY_CA_CERT`          | —                  | PEM CA bundle (TLS only) |
+| `--tls-skip-verify` | `MACHINERY_TLS_SKIP_VERIFY`  | `false`            | dev only |
+| `--token`           | `MACHINERY_AUTH_TOKEN`       | —                  | bearer token; sent as `authorization: Bearer <token>` |
+| `--timeout`         | —                            | `10s`              | per-RPC deadline |
+| `--json`            | —                            | `false`            | emit JSON instead of a table |
+
+## Three ways to call machinery
+
+### 1. In-cluster (or `kubectl port-forward`)
+
+Inside the cluster the Service is reachable directly; from your laptop
+the easiest path is port-forward. No TLS, no auth needed unless
+`auth.enabled` is on in the server config.
+
+```bash
+kubectl -n machinery port-forward svc/machinery 50051:50051 &
+
+./consumer list --kind=VsphereVMAnsible --count=10
+./consumer get  --kind=VsphereVMAnsible --name=demo-vm --namespace=demo
+./consumer health
+```
+
+If the server has auth enabled, add `--token=$(cat /path/to/token)` or
+`export MACHINERY_AUTH_TOKEN=…` and the same commands will work.
+
+### 2. Via the `GRPCRoute` from a LAN host
+
+Once the [GRPCRoute is applied](../../kcl/grpcroute.k), machinery is
+addressable at the hostname your gateway listener exposes — e.g.
+`machinery.example.com:443` for a TLS listener. Replace
+`machinery.example.com` with whatever you set as `grpcRouteHostname`.
+
+```bash
+export MACHINERY_SERVER=machinery.example.com:443
+export MACHINERY_AUTH_TOKEN=$(kubectl -n machinery get secret machinery-auth -o jsonpath='{.data.token}' | base64 -d)
+
+./consumer list --insecure=false --kind='*' --count=20
+./consumer health --insecure=false
+```
+
+Use `--ca-cert=/path/to/ca.pem` if the gateway presents a private CA,
+or `--tls-skip-verify` for a quick smoke test while you're chasing a
+cert issue. The bearer token is sent over TLS only by default — if you
+need to send it over plaintext for LAN debugging, pass `--insecure` and
+the example flips `RequireTransportSecurity` for you (see
+`bearerToken` in `main.go`).
+
+### 3. `grpcurl` — "I don't want to write Go"
+
+The proto is small enough that the no-code path is fast. Same gateway
+address, same token, ad-hoc requests:
+
+Machinery does **not** register the gRPC reflection service, so
+`grpcurl` needs the proto file to know the message shapes. Point it at
+the one in this repo (or a checkout of it):
+
+```bash
+PROTO=$(git rev-parse --show-toplevel)/resourceservice/resource_service.proto
+
+# Health check — does the route reach a pod at all? (no proto needed)
+grpcurl machinery.example.com:443 grpc.health.v1.Health/Check
+
+# List five VsphereVMAnsible resources.
+grpcurl \
+  -proto "$PROTO" \
+  -H "authorization: Bearer $MACHINERY_AUTH_TOKEN" \
+  -d '{"count": 5, "kind": "VsphereVMAnsible"}' \
+  machinery.example.com:443 \
+  resourceservice.ResourceService/GetResources
+
+# Get one. Drop "namespace" for cluster-scoped CRs.
+grpcurl \
+  -proto "$PROTO" \
+  -H "authorization: Bearer $MACHINERY_AUTH_TOKEN" \
+  -d '{"kind": "VsphereVMAnsible", "name": "demo-vm", "namespace": "demo"}' \
+  machinery.example.com:443 \
+  resourceservice.ResourceService/GetResourceDetail
+```
+
+The `grpc.health.v1.Health` service is registered without a `-proto`
+because `grpcurl` ships the health proto built in. Add `-plaintext` if
+you're hitting an in-cluster port-forward instead of the gateway.
+
+## JSON output
+
+Both `list` and `get` accept `--json`, useful for piping into `jq` or
+embedding in another tool:
+
+```bash
+./consumer list --kind=VsphereVMAnsible --json | jq '.[] | select(.ready) | .name'
+```
+
+## What's intentionally *not* here
+
+- A daemon / polling loop. The "consume machinery on a timer" use
+  case (the `examples/consumer-webservice/` idea from
+  [#57](https://github.com/stuttgart-things/machinery/issues/57)) is
+  intentionally left as a follow-up to keep this example focused on
+  the one-shot call patterns.
+- Client code for other languages. `grpcurl` covers most quick cases;
+  for Python/TS, generate from
+  [`resourceservice/resource_service.proto`](../../resourceservice/resource_service.proto)
+  with the standard tooling.
+- A release artifact. This is example code — vendor it or use it as a
+  reference, don't depend on a binary release.

--- a/examples/consumer/main.go
+++ b/examples/consumer/main.go
@@ -1,0 +1,352 @@
+// Command consumer is an example client for the machinery gRPC service.
+// It demonstrates the two RPCs (GetResources / GetResourceDetail), the
+// health probe, and the connection plumbing (plaintext, TLS with a custom
+// CA, bearer-token auth) downstream consumers are expected to wire up.
+//
+// It is deliberately a single file so the relevant snippets (dial,
+// bearerToken, error handling) can be copied into another service.
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	resourceservice "github.com/stuttgart-things/maschinist/resourceservice"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/status"
+)
+
+const usage = `consumer — example client for the machinery gRPC service.
+
+Usage:
+  consumer <command> [flags]
+
+Commands:
+  list      Call GetResources (machinery's "browse" endpoint)
+  get       Call GetResourceDetail (single CR with info fields)
+  health    Call grpc.health.v1.Health/Check (does the route answer?)
+
+Connection flags (accepted on every subcommand):
+  --server            host:port               (env MACHINERY_SERVER, default localhost:50051)
+  --insecure          plaintext gRPC          (env MACHINERY_INSECURE, default true)
+  --ca-cert           PEM CA bundle for TLS   (env MACHINERY_CA_CERT)
+  --tls-skip-verify   skip TLS verify (dev)   (env MACHINERY_TLS_SKIP_VERIFY)
+  --token             bearer token            (env MACHINERY_AUTH_TOKEN)
+  --timeout           per-RPC timeout         (default 10s)
+  --json              emit JSON, not a table
+
+Run "consumer <command> --help" for command-specific flags.
+`
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprint(os.Stderr, usage)
+		os.Exit(2)
+	}
+	switch os.Args[1] {
+	case "list":
+		os.Exit(runList(os.Args[2:]))
+	case "get":
+		os.Exit(runGet(os.Args[2:]))
+	case "health":
+		os.Exit(runHealth(os.Args[2:]))
+	case "-h", "--help", "help":
+		fmt.Print(usage)
+	default:
+		fmt.Fprintf(os.Stderr, "unknown command %q\n\n", os.Args[1])
+		fmt.Fprint(os.Stderr, usage)
+		os.Exit(2)
+	}
+}
+
+// commonFlags holds the connection plumbing every subcommand shares.
+type commonFlags struct {
+	server        string
+	insecure      bool
+	caCert        string
+	tlsSkipVerify bool
+	token         string
+	timeout       time.Duration
+	asJSON        bool
+}
+
+func registerCommon(fs *flag.FlagSet, c *commonFlags) {
+	fs.StringVar(&c.server, "server", envOr("MACHINERY_SERVER", "localhost:50051"), "gRPC server address (host:port)")
+	fs.BoolVar(&c.insecure, "insecure", envBool("MACHINERY_INSECURE", true), "use plaintext gRPC (no TLS)")
+	fs.StringVar(&c.caCert, "ca-cert", os.Getenv("MACHINERY_CA_CERT"), "path to PEM CA bundle (TLS only)")
+	fs.BoolVar(&c.tlsSkipVerify, "tls-skip-verify", envBool("MACHINERY_TLS_SKIP_VERIFY", false), "skip TLS verification (dev only)")
+	fs.StringVar(&c.token, "token", os.Getenv("MACHINERY_AUTH_TOKEN"), "bearer token; sent as `authorization: Bearer <token>` (pairs with auth interceptor)")
+	fs.DurationVar(&c.timeout, "timeout", 10*time.Second, "per-RPC timeout")
+	fs.BoolVar(&c.asJSON, "json", false, "emit JSON instead of a human-readable table")
+}
+
+func runList(args []string) int {
+	fs := flag.NewFlagSet("list", flag.ContinueOnError)
+	var c commonFlags
+	registerCommon(fs, &c)
+	kind := fs.String("kind", "*", "kind to fetch (* for every configured kind)")
+	count := fs.Int("count", 5, "max resources to return (-1 = all)")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	conn, err := dial(c)
+	if err != nil {
+		return fail(err)
+	}
+	defer conn.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
+	defer cancel()
+
+	resp, err := resourceservice.NewResourceServiceClient(conn).GetResources(ctx, &resourceservice.ResourceRequest{
+		Count: int32(*count),
+		Kind:  *kind,
+	})
+	if err != nil {
+		return fail(err)
+	}
+
+	if c.asJSON {
+		return emitJSON(resp.Resources)
+	}
+	return emitTable(resp.Resources)
+}
+
+func runGet(args []string) int {
+	fs := flag.NewFlagSet("get", flag.ContinueOnError)
+	var c commonFlags
+	registerCommon(fs, &c)
+	kind := fs.String("kind", "", "kind (required)")
+	name := fs.String("name", "", "resource name (required)")
+	namespace := fs.String("namespace", "", "namespace (omit for cluster-scoped resources)")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if *kind == "" || *name == "" {
+		fmt.Fprintln(os.Stderr, "--kind and --name are required")
+		fs.Usage()
+		return 2
+	}
+
+	conn, err := dial(c)
+	if err != nil {
+		return fail(err)
+	}
+	defer conn.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
+	defer cancel()
+
+	r, err := resourceservice.NewResourceServiceClient(conn).GetResourceDetail(ctx, &resourceservice.ResourceDetailRequest{
+		Kind:      *kind,
+		Name:      *name,
+		Namespace: *namespace,
+	})
+	if err != nil {
+		return fail(err)
+	}
+
+	if c.asJSON {
+		return emitJSON(r)
+	}
+	return emitDetail(r)
+}
+
+func runHealth(args []string) int {
+	fs := flag.NewFlagSet("health", flag.ContinueOnError)
+	var c commonFlags
+	registerCommon(fs, &c)
+	service := fs.String("service", "", "gRPC service name to check (empty = overall server health)")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	conn, err := dial(c)
+	if err != nil {
+		return fail(err)
+	}
+	defer conn.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
+	defer cancel()
+
+	resp, err := healthpb.NewHealthClient(conn).Check(ctx, &healthpb.HealthCheckRequest{Service: *service})
+	if err != nil {
+		return fail(err)
+	}
+	fmt.Println(resp.Status.String())
+	if resp.Status != healthpb.HealthCheckResponse_SERVING {
+		return 1
+	}
+	return 0
+}
+
+// dial wires up TLS + optional bearer-token auth and returns a connection.
+func dial(c commonFlags) (*grpc.ClientConn, error) {
+	var opts []grpc.DialOption
+
+	if c.insecure {
+		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	} else {
+		tlsCfg := &tls.Config{}
+		switch {
+		case c.tlsSkipVerify:
+			tlsCfg.InsecureSkipVerify = true
+		case c.caCert != "":
+			pem, err := os.ReadFile(c.caCert)
+			if err != nil {
+				return nil, fmt.Errorf("reading --ca-cert: %w", err)
+			}
+			pool := x509.NewCertPool()
+			if !pool.AppendCertsFromPEM(pem) {
+				return nil, fmt.Errorf("--ca-cert: no certificates parsed")
+			}
+			tlsCfg.RootCAs = pool
+		}
+		opts = append(opts, grpc.WithTransportCredentials(credentials.NewTLS(tlsCfg)))
+	}
+
+	if c.token != "" {
+		opts = append(opts, grpc.WithPerRPCCredentials(bearerToken{token: c.token, insecure: c.insecure}))
+	}
+
+	return grpc.NewClient(c.server, opts...)
+}
+
+// bearerToken is the smallest grpc.PerRPCCredentials implementation that
+// pairs with machinery's auth interceptor — `authorization: Bearer <token>`
+// on every outgoing RPC. RequireTransportSecurity is flipped off when
+// --insecure is set so the same struct works on plaintext (LAN/dev) and
+// TLS dial paths.
+type bearerToken struct {
+	token    string
+	insecure bool
+}
+
+func (b bearerToken) GetRequestMetadata(_ context.Context, _ ...string) (map[string]string, error) {
+	return map[string]string{"authorization": "Bearer " + b.token}, nil
+}
+
+func (b bearerToken) RequireTransportSecurity() bool { return !b.insecure }
+
+func emitTable(rs []*resourceservice.ResourceStatus) int {
+	if len(rs) == 0 {
+		fmt.Println("(no resources)")
+		return 0
+	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "KIND\tNAMESPACE\tNAME\tREADY\tSTATUS\tCONNECTION")
+	for _, r := range rs {
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
+			r.Kind, dash(r.Namespace), r.Name, boolStr(r.Ready), trunc(r.StatusMessage, 60), trunc(r.ConnectionDetails, 60),
+		)
+	}
+	return flush(w)
+}
+
+func emitDetail(r *resourceservice.ResourceStatus) int {
+	fmt.Printf("Kind:        %s\n", r.Kind)
+	fmt.Printf("Namespace:   %s\n", dash(r.Namespace))
+	fmt.Printf("Name:        %s\n", r.Name)
+	fmt.Printf("Ready:       %s\n", boolStr(r.Ready))
+	fmt.Printf("Status:      %s\n", r.StatusMessage)
+	fmt.Printf("Connection:  %s\n", r.ConnectionDetails)
+	if len(r.InfoFields) > 0 {
+		fmt.Println("Info:")
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		for k, v := range r.InfoFields {
+			fmt.Fprintf(w, "  %s\t%s\n", k, v)
+		}
+		return flush(w)
+	}
+	return 0
+}
+
+func emitJSON(v any) int {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(v); err != nil {
+		return fail(err)
+	}
+	return 0
+}
+
+func flush(w *tabwriter.Writer) int {
+	if err := w.Flush(); err != nil {
+		return fail(err)
+	}
+	return 0
+}
+
+func dash(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}
+
+func boolStr(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
+}
+
+func trunc(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n-1] + "…"
+}
+
+// fail prints a "code: message" line and returns a non-zero exit code.
+// gRPC status errors are unwrapped so callers see e.g.
+// "Unauthenticated: invalid token" rather than the long rpc-error string.
+func fail(err error) int {
+	if err == nil {
+		return 0
+	}
+	var msg string
+	switch {
+	case errors.Is(err, context.DeadlineExceeded):
+		msg = "timeout"
+	default:
+		if st, ok := status.FromError(err); ok {
+			msg = fmt.Sprintf("%s: %s", st.Code(), st.Message())
+		} else {
+			msg = err.Error()
+		}
+	}
+	fmt.Fprintln(os.Stderr, "error:", msg)
+	return 1
+}
+
+func envOr(key, fallback string) string {
+	if v := strings.TrimSpace(os.Getenv(key)); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func envBool(key string, fallback bool) bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(key))) {
+	case "true", "1", "yes":
+		return true
+	case "false", "0", "no":
+		return false
+	}
+	return fallback
+}


### PR DESCRIPTION
## Summary

- New `examples/consumer/` package: a small Go CLI (`list` / `get` / `health` subcommands) showing how to call machinery's gRPC service from outside the cluster — the copy-from-me example that `client/client.go` was never trying to be.
- Common connection flags (`--server`, `--insecure`, `--ca-cert`, `--tls-skip-verify`, `--token`, `--timeout`, `--json`) wire up the three transports we care about: in-cluster plaintext, TLS via gateway listener, and gateway + bearer token (#56).
- README walks through all three invocation modes plus `grpcurl` equivalents. Notes that machinery does not register the reflection service, so `grpcurl` needs `-proto resourceservice/resource_service.proto`.

Closes #57. Leaves the optional `examples/consumer-webservice/` polling-loop example out of scope per the issue's own guidance — flagged in the README as a follow-up.

## Test plan

- [x] `go build ./examples/consumer/...` clean
- [x] `go vet ./examples/consumer/...` clean
- [x] `go test ./...` still green
- [x] `consumer list --server=127.0.0.1:1 --timeout=2s` → `Unavailable: connection error: ...`, exit 1 (clean gRPC code surfaced)
- [x] `consumer get` with missing required flags → validation error, exit 2
- [x] `consumer --help` and `consumer <cmd> --help` print useful usage
- [ ] Preview env: hit machinery's gRPCRoute from outside the cluster using the CLI (auth on + auth off paths)
- [ ] Preview env: `grpcurl -proto …/resource_service.proto` against the same endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)