### PR TITLE
fix(kcl): set appProtocol h2c on gRPC Service port

### DIFF
--- a/kcl/service.k
+++ b/kcl/service.k
@@ -22,6 +22,9 @@ service = {
                 port: config.grpcPort
                 targetPort: "grpc"
                 protocol: "TCP"
+                # Tells the Gateway the backend speaks HTTP/2 cleartext, so
+                # gRPC is routed correctly once TLS is terminated at the edge.
+                appProtocol: "kubernetes.io/h2c"
             }
         ] + ([
             {


### PR DESCRIPTION
## Why

gRPC over TLS through the Cilium Gateway was unreachable off-cluster. Cilium's
HTTPS listeners advertised no ALPN, so the TLS handshake failed before any gRPC
frames were exchanged — every `GRPCRoute` was effectively dead from outside the
cluster.

The Cilium side of the fix lives in `stuttgart-things/argocd`
(setting `gatewayAPI.enableAlpn: true`, so listeners now advertise `h2,http/1.1`):
- argocd PR: stuttgart-things/argocd#188
- resolves: stuttgart-things/argocd#184

But that listener fix alone is not sufficient. The Gateway also needs a
per-port hint on the **backend Service** describing the upstream protocol.
machinery's gRPC server speaks HTTP/2 cleartext in-cluster (TLS is terminated at
the edge), and the gRPC `Service` port in `kcl/service.k` carried no
`appProtocol`. Without it the Gateway does not route HTTP/2 / gRPC traffic to
the backend correctly.

## What

Set `appProtocol: kubernetes.io/h2c` on the gRPC port in `kcl/service.k`.

It is hardcoded rather than schema-configurable — the `grpc` port always serves
gRPC/h2c, consistent with how `name`, `targetPort`, and `protocol` are already
fixed on that port.

The `GRPCRoute` template (`kcl/grpcroute.k`) was already correct and is
unchanged.

## Result

Once `homerun2-dev` syncs the updated Cilium install, the machinery gRPC
endpoint is reachable over TLS through the Gateway.

## Test plan

- [ ] Render KCL and confirm the `grpc` Service port carries `appProtocol: kubernetes.io/h2c`
      (`kcl run kcl/main.k -Y tests/kcl-deploy-profile.yaml`)
- [ ] After `homerun2-dev` syncs, verify off-cluster reachability over TLS, e.g.
      `grpcurl machinery-grpc.<host>:443 grpc.health.v1.Health/Check`

https://claude.ai/code/session_01F7YtR8kM3v51ZCg7E9M95B

---
_Generated by [Claude Code](https://claude.ai/code/session_01F7YtR8kM3v51ZCg7E9M95B)_