### PR TITLE
docs(kcl): note Gateway ALPN h2 requirement for off-cluster gRPC

### DIFF
--- a/kcl/README.md
+++ b/kcl/README.md
@@ -145,6 +145,14 @@ grpcurl -H "authorization: Bearer ${TOKEN}" \
   resourceservice.ResourceService/GetResources
 ```
 
+> **Off-cluster gRPC over `:443` needs HTTP/2 ALPN on the Gateway.** gRPC
+> mandates HTTP/2; if the Cilium Gateway's HTTPS listener doesn't advertise
+> `h2` in its TLS ALPN the commands above fail at the handshake
+> (`No ALPN negotiated`) before any gRPC frames are exchanged. ALPN is not a
+> Gateway API or KCL field — it's the Cilium **install** value
+> `gatewayAPI.enableAlpn: true`, which also turns on `appProtocol` support so
+> the gRPC Service port's `appProtocol: kubernetes.io/h2c` is honored upstream.
+
 The HTMX dashboard is unaffected — its calls are in-process and bypass the
 interceptor. `/grpc.health.v1.Health/*` also stays anonymous, so liveness/readiness
 probes keep working without the token.


### PR DESCRIPTION
## Summary

Adds a callout in `kcl/README.md` (gRPC auth section) that off-cluster gRPC over the Gateway's HTTPS `:443` listener requires `h2` in the TLS ALPN — which comes from the Cilium **install** value `gatewayAPI.enableAlpn`, not from the Gateway/GRPCRoute or the KCL base. Without it the `grpcurl … :443` examples fail at the handshake with `No ALPN negotiated`.

## Why `preview`

Labelled `preview` to spin up a per-PR env on homerun2-dev and validate gRPC-over-Gateway end-to-end now that `gatewayAPI.enableAlpn: true` is live on that cluster's Cilium (the HTTPS listener negotiates `h2` as of 2026-05-21). Docs-only change — the image and kustomize artifacts build the same as `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)