### PR TITLE
feat(grpc): serve resource reads from a shared informer cache

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,18 +11,21 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
@@ -37,6 +40,7 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	k8s.io/api v0.36.1 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -83,6 +83,8 @@ go.opentelemetry.io/otel/sdk/metric v1.43.0 h1:S88dyqXjJkuBNLeMcVPRFXpRw2fuwdvfC
 go.opentelemetry.io/otel/sdk/metric v1.43.0/go.mod h1:C/RJtwSEJ5hzTiUz5pXF1kILHStzb9zFlIEe85bhj6A=
 go.opentelemetry.io/otel/trace v1.43.0 h1:BkNrHpup+4k4w+ZZ86CZoHHEkohws8AY+WTX09nk+3A=
 go.opentelemetry.io/otel/trace v1.43.0/go.mod h1:/QJhyVBUUswCphDVxq+8mld+AvhXZLhe+8WVFxiFff0=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.yaml.in/yaml/v2 v2.4.3 h1:6gvOSjQoTB3vt1l+CU+tSyi/HOjfOjRLJ4YwYZGwRO0=
 go.yaml.in/yaml/v2 v2.4.3/go.mod h1:zSxWcmIDjOzPXpjlTTbAsKokqkDNAVtZO0WOMiT90s8=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=

--- a/main.go
+++ b/main.go
@@ -9,8 +9,10 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"sort"
 	"strings"
 	"syscall"
+	"time"
 
 	resourceservice "github.com/stuttgart-things/maschinist/resourceservice"
 
@@ -24,7 +26,11 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -33,10 +39,19 @@ var (
 	configPath = os.Getenv("MACHINERY_CONFIG")
 )
 
+// informerResync is the dynamic informer factory's resync period. The
+// watch keeps each cache fresh on its own; resync only re-delivers the
+// full set to event handlers periodically — harmless here, and a sane
+// default for the WatchResources work that builds on this cache.
+const informerResync = 10 * time.Minute
+
 type server struct {
 	resourceservice.UnimplementedResourceServiceServer
-	dynamicClient dynamic.Interface
-	config        *Config
+	config *Config
+	// listers holds one cache-backed lister per configured kind the
+	// cluster actually serves. Populated by startInformers; reads never
+	// hit the API server. A kind absent here was not served at startup.
+	listers map[string]cache.GenericLister
 }
 
 func main() {
@@ -72,6 +87,14 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Informer caches replace the old per-request List/Get against the
+	// API server: one watch per configured kind, shared by every gRPC
+	// call and every dashboard poll. stopCh tears them down on shutdown.
+	// This blocks until the caches warm, so the gRPC/HTTP servers below
+	// only start serving once reads can be answered from cache.
+	stopCh := make(chan struct{})
+	listers := startInformers(dynamicClient, cfg, stopCh)
+
 	addr := fmt.Sprintf(":%d", cfg.Port)
 	lis, err := net.Listen("tcp", addr)
 	if err != nil {
@@ -79,7 +102,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	srv := &server{dynamicClient: dynamicClient, config: cfg}
+	srv := &server{config: cfg, listers: listers}
 
 	var grpcOpts []grpc.ServerOption
 	if cfg.Auth.Enabled {
@@ -130,6 +153,7 @@ func main() {
 		sig := <-sigCh
 		slog.Info("received shutdown signal", "signal", sig)
 		healthServer.SetServingStatus("", healthpb.HealthCheckResponse_NOT_SERVING)
+		close(stopCh)
 		httpServer.Shutdown(context.Background())
 		s.GracefulStop()
 	}()
@@ -140,6 +164,57 @@ func main() {
 		os.Exit(1)
 	}
 	slog.Info("server stopped")
+}
+
+// startInformers probes each configured kind, attaches a dynamic
+// informer for the ones the cluster actually serves, waits (bounded)
+// for their caches to warm, and returns one lister per live kind.
+// Kinds the API server does not serve (CRD absent, API version
+// retired) are skipped with a warning — one missing kind must not
+// stop the others, the same tolerance the old per-request List path
+// had. The informers run until stopCh is closed.
+func startInformers(dc dynamic.Interface, cfg *Config, stopCh <-chan struct{}) map[string]cache.GenericLister {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	factory := dynamicinformer.NewDynamicSharedInformerFactory(dc, informerResync)
+	listers := make(map[string]cache.GenericLister, len(cfg.Resources))
+
+	for kind, rk := range cfg.Resources {
+		gvr := rk.toGVR()
+		// One probe List per kind at startup (not per request): tells
+		// us whether the cluster serves this GVR before we attach an
+		// informer whose reflector would otherwise retry-spam forever.
+		if _, err := dc.Resource(gvr).List(ctx, metav1.ListOptions{Limit: 1}); err != nil {
+			if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
+				slog.Warn("kind not served by cluster, skipping",
+					"kind", kind, "gvr", gvr.String())
+				continue
+			}
+			// Other errors (RBAC, transient API hiccup) — attach the
+			// informer anyway; its reflector retries and the lister
+			// fills in once access works.
+			slog.Warn("kind probe failed, attaching informer anyway",
+				"kind", kind, "gvr", gvr.String(), "error", err)
+		}
+		listers[kind] = factory.ForResource(gvr).Lister()
+	}
+
+	if len(listers) == 0 {
+		slog.Warn("no configured kinds are served by the cluster; resource queries will be empty")
+		return listers
+	}
+
+	factory.Start(stopCh)
+	slog.Info("waiting for informer cache sync", "kinds", len(listers))
+	for typ, ok := range factory.WaitForCacheSync(ctx.Done()) {
+		if !ok {
+			slog.Warn("informer cache did not sync before timeout; results may be briefly incomplete",
+				"type", typ.String())
+		}
+	}
+	slog.Info("informer caches ready", "kinds", len(listers))
+	return listers
 }
 
 func (s *server) GetResources(ctx context.Context, req *resourceservice.ResourceRequest) (*resourceservice.ResourceListResponse, error) {
@@ -175,33 +250,35 @@ func (s *server) GetResources(ctx context.Context, req *resourceservice.Resource
 
 	for _, kind := range kinds {
 		rk := s.config.Resources[kind]
-		gvr := rk.toGVR()
 
-		slog.Debug("fetching resources", "kind", kind, "gvr", gvr.Resource)
-
-		resourceList, err := s.dynamicClient.Resource(gvr).List(ctx, metav1.ListOptions{})
-		if err != nil {
-			// Skip kinds the API server no longer serves (CRD removed,
-			// API version retired, beta graduated to stable, …). One
-			// broken kind shouldn't blank the dashboard for kinds that
-			// do work — log loudly so operators can spot config drift.
-			if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
-				slog.Warn("kind not available on cluster, skipping",
-					"kind", kind, "gvr", gvr.String(), "error", err)
-				continue
-			}
-			return nil, fmt.Errorf("error fetching resources for kind %s: %w", kind, err)
+		lister, ok := s.listers[kind]
+		if !ok {
+			// No informer for this kind — the cluster did not serve it
+			// at startup (CRD removed, API version retired). Skip, as
+			// the old per-request List path did on IsNotFound/NoMatch.
+			slog.Warn("kind has no informer cache, skipping", "kind", kind)
+			continue
 		}
 
-		for _, item := range resourceList.Items {
+		objs, err := lister.List(labels.Everything())
+		if err != nil {
+			return nil, fmt.Errorf("error listing cached resources for kind %s: %w", kind, err)
+		}
+
+		for _, obj := range objs {
 			if req.Count == 0 {
 				break
 			}
-			statusMessage, ready := getResourceStatus(&item)
+			item, ok := obj.(*unstructured.Unstructured)
+			if !ok {
+				continue
+			}
 
-			connDetails := getConnectionDetails(&item, rk.ConnectionField)
+			statusMessage, ready := getResourceStatus(item)
+
+			connDetails := getConnectionDetails(item, rk.ConnectionField)
 			if len(rk.StatusFields) > 0 {
-				extra := getStatusDetails(&item, rk.StatusFields)
+				extra := getStatusDetails(item, rk.StatusFields)
 				if extra != "" {
 					if connDetails != "" {
 						connDetails = connDetails + " | " + extra
@@ -211,7 +288,7 @@ func (s *server) GetResources(ctx context.Context, req *resourceservice.Resource
 				}
 			}
 
-			infoFields := getInfoFields(&item, rk.InfoFields)
+			infoFields := getInfoFields(item, rk.InfoFields)
 
 			allResources = append(allResources, &resourceservice.ResourceStatus{
 				Name:              item.GetName(),
@@ -228,6 +305,19 @@ func (s *server) GetResources(ctx context.Context, req *resourceservice.Resource
 			}
 		}
 	}
+
+	// Informer stores are unordered; sort for a stable response so the
+	// dashboard rows don't shuffle between polls.
+	sort.Slice(allResources, func(i, j int) bool {
+		a, b := allResources[i], allResources[j]
+		if a.Kind != b.Kind {
+			return a.Kind < b.Kind
+		}
+		if a.Namespace != b.Namespace {
+			return a.Namespace < b.Namespace
+		}
+		return a.Name < b.Name
+	})
 
 	slog.Info("resources fetched", "count", len(allResources))
 	return &resourceservice.ResourceListResponse{Resources: allResources}, nil
@@ -337,15 +427,27 @@ func (s *server) GetResourceDetail(ctx context.Context, req *resourceservice.Res
 		return nil, status.Errorf(codes.InvalidArgument, "unsupported kind %q", req.Kind)
 	}
 
-	gvr := rk.toGVR()
-	ns := req.Namespace
-	if ns == "" {
-		ns = "default"
+	lister, ok := s.listers[req.Kind]
+	if !ok {
+		return nil, status.Errorf(codes.Unavailable, "kind %q is not served by the cluster", req.Kind)
 	}
 
-	item, err := s.dynamicClient.Resource(gvr).Namespace(ns).Get(ctx, req.Name, metav1.GetOptions{})
+	// Namespaced lookups key on namespace/name; cluster-scoped (or a
+	// caller that omits the namespace) on name alone.
+	var obj runtime.Object
+	var err error
+	if req.Namespace != "" {
+		obj, err = lister.ByNamespace(req.Namespace).Get(req.Name)
+	} else {
+		obj, err = lister.Get(req.Name)
+	}
 	if err != nil {
 		return nil, status.Errorf(codes.NotFound, "resource %s/%s not found: %v", req.Kind, req.Name, err)
+	}
+
+	item, ok := obj.(*unstructured.Unstructured)
+	if !ok {
+		return nil, status.Errorf(codes.Internal, "unexpected cached object type for %s/%s", req.Kind, req.Name)
 	}
 
 	statusMessage, ready := getResourceStatus(item)

--- a/main_test.go
+++ b/main_test.go
@@ -18,29 +18,37 @@ import (
 )
 
 var testListKinds = map[schema.GroupVersionResource]string{
-	{Group: "resources.stuttgart-things.com", Version: "v1alpha1", Resource: "harvestervms"}:         "HarvesterVMList",
-	{Group: "resources.stuttgart-things.com", Version: "v1alpha1", Resource: "storageplatforms"}:     "StoragePlatformList",
-	{Group: "resources.stuttgart-things.com", Version: "v1alpha1", Resource: "networkintegrations"}:  "NetworkIntegrationList",
+	{Group: "resources.stuttgart-things.com", Version: "v1alpha1", Resource: "harvestervms"}:        "HarvesterVMList",
+	{Group: "resources.stuttgart-things.com", Version: "v1alpha1", Resource: "storageplatforms"}:    "StoragePlatformList",
+	{Group: "resources.stuttgart-things.com", Version: "v1alpha1", Resource: "networkintegrations"}: "NetworkIntegrationList",
 }
 
-func newTestServer(objects ...runtime.Object) *server {
+func newTestServer(t *testing.T, objects ...runtime.Object) *server {
+	t.Helper()
 	scheme := runtime.NewScheme()
 	fakeClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, testListKinds, objects...)
-	return &server{
-		dynamicClient: fakeClient,
-		config:        defaultConfig(),
-	}
+	return buildTestServer(t, fakeClient, defaultConfig())
 }
 
-// newTestServerWithMissingKind builds a server whose fake dynamic
-// client knows the given GVR (so it doesn't panic on a List call)
-// but a reactor intercepts that List and returns NotFound — the
-// same response shape the real API server uses when a CRD is gone
-// or a beta API version has been retired. The fake's "kind is
-// registered with customListKinds" check runs *before* reactors,
-// so the GVR has to be in the kind map for the reactor to even
-// get a chance.
-func newTestServerWithMissingKind(missing schema.GroupVersionResource, listKind string, objects ...runtime.Object) *server {
+// buildTestServer wires the production startInformers() against a fake
+// dynamic client, so tests exercise the same informer-cache read path
+// as the running server. The informers are torn down via t.Cleanup.
+func buildTestServer(t *testing.T, dc *dynamicfake.FakeDynamicClient, cfg *Config) *server {
+	t.Helper()
+	stopCh := make(chan struct{})
+	t.Cleanup(func() { close(stopCh) })
+	return &server{config: cfg, listers: startInformers(dc, cfg, stopCh)}
+}
+
+// fakeClientWithMissingKind builds a fake dynamic client that knows the
+// given GVR's list-kind (so List doesn't panic) but whose List reactor
+// returns NotFound — the same response shape the real API server uses
+// when a CRD is gone or a beta API version has been retired. The fake's
+// "kind is registered with customListKinds" check runs *before*
+// reactors, so the GVR has to be in the kind map for the reactor to get
+// a chance. startInformers' startup probe sees the NotFound and skips
+// the kind, attaching no informer for it.
+func fakeClientWithMissingKind(missing schema.GroupVersionResource, listKind string, objects ...runtime.Object) *dynamicfake.FakeDynamicClient {
 	scheme := runtime.NewScheme()
 	kinds := map[schema.GroupVersionResource]string{}
 	for k, v := range testListKinds {
@@ -51,7 +59,7 @@ func newTestServerWithMissingKind(missing schema.GroupVersionResource, listKind 
 	fakeClient.PrependReactor("list", missing.Resource, func(action clienttesting.Action) (bool, runtime.Object, error) {
 		return true, nil, apierrors.NewNotFound(schema.GroupResource{Group: missing.Group, Resource: missing.Resource}, "")
 	})
-	return &server{dynamicClient: fakeClient, config: defaultConfig()}
+	return fakeClient
 }
 
 func TestGetResources_SkipsKindsMissingFromCluster(t *testing.T) {
@@ -70,14 +78,16 @@ func TestGetResources_SkipsKindsMissingFromCluster(t *testing.T) {
 		Group: "resources.stuttgart-things.com", Version: "v1alpha1", Kind: "HarvesterVM",
 	})
 
-	// One healthy kind from defaultConfig, plus an additional kind
-	// the (simulated) cluster doesn't serve. With the resilience fix
-	// the call should succeed and just drop the broken kind.
+	// defaultConfig's healthy kinds, plus one the (simulated) cluster
+	// doesn't serve. The missing kind must be in the config *before*
+	// the server is built, so startInformers' startup probe is what
+	// drops it — the call should then succeed and just omit that kind.
 	missing := schema.GroupVersionResource{Group: "example.com", Version: "v1beta1", Resource: "gonefromclusters"}
-	s := newTestServerWithMissingKind(missing, "GoneFromClusterList", vm)
-	s.config.Resources["GoneFromCluster"] = ResourceKind{
+	cfg := defaultConfig()
+	cfg.Resources["GoneFromCluster"] = ResourceKind{
 		Group: missing.Group, Version: missing.Version, Resource: missing.Resource,
 	}
+	s := buildTestServer(t, fakeClientWithMissingKind(missing, "GoneFromClusterList", vm), cfg)
 
 	resp, err := s.GetResources(context.Background(), &resourceservice.ResourceRequest{
 		Kind:  "*",
@@ -100,10 +110,14 @@ func TestGetResources_AllKindsMissingReturnsEmpty(t *testing.T) {
 	// instead of an HTTP 500. Failing loudly here would only make
 	// every fresh install with a stale config look broken.
 	missing := schema.GroupVersionResource{Group: "example.com", Version: "v1beta1", Resource: "onlygonekinds"}
-	s := newTestServerWithMissingKind(missing, "OnlyGoneKindList")
-	s.config.Resources = map[string]ResourceKind{
-		"OnlyGoneKind": {Group: missing.Group, Version: missing.Version, Resource: missing.Resource},
+	cfg := &Config{
+		Port:     50051,
+		HttpPort: 8080,
+		Resources: map[string]ResourceKind{
+			"OnlyGoneKind": {Group: missing.Group, Version: missing.Version, Resource: missing.Resource},
+		},
 	}
+	s := buildTestServer(t, fakeClientWithMissingKind(missing, "OnlyGoneKindList"), cfg)
 
 	resp, err := s.GetResources(context.Background(), &resourceservice.ResourceRequest{
 		Kind:  "*",
@@ -118,7 +132,7 @@ func TestGetResources_AllKindsMissingReturnsEmpty(t *testing.T) {
 }
 
 func TestGetResources_InvalidKind(t *testing.T) {
-	s := newTestServer()
+	s := newTestServer(t)
 	_, err := s.GetResources(context.Background(), &resourceservice.ResourceRequest{
 		Kind:  "NonExistent",
 		Count: 5,
@@ -136,7 +150,7 @@ func TestGetResources_InvalidKind(t *testing.T) {
 }
 
 func TestGetResources_InvalidCount(t *testing.T) {
-	s := newTestServer()
+	s := newTestServer(t)
 	_, err := s.GetResources(context.Background(), &resourceservice.ResourceRequest{
 		Kind:  "HarvesterVM",
 		Count: 5000,
@@ -154,7 +168,7 @@ func TestGetResources_InvalidCount(t *testing.T) {
 }
 
 func TestGetResources_EmptyResult(t *testing.T) {
-	s := newTestServer()
+	s := newTestServer(t)
 	resp, err := s.GetResources(context.Background(), &resourceservice.ResourceRequest{
 		Kind:  "HarvesterVM",
 		Count: -1,
@@ -202,7 +216,7 @@ func TestGetResources_WithResources(t *testing.T) {
 		Kind:    "HarvesterVM",
 	})
 
-	s := newTestServer(obj)
+	s := newTestServer(t, obj)
 
 	resp, err := s.GetResources(context.Background(), &resourceservice.ResourceRequest{
 		Kind:  "HarvesterVM",
@@ -253,7 +267,7 @@ func TestGetResources_CountLimit(t *testing.T) {
 		objects = append(objects, obj)
 	}
 
-	s := newTestServer(objects...)
+	s := newTestServer(t, objects...)
 
 	resp, err := s.GetResources(context.Background(), &resourceservice.ResourceRequest{
 		Kind:  "HarvesterVM",
@@ -267,12 +281,63 @@ func TestGetResources_CountLimit(t *testing.T) {
 	}
 }
 
+func TestGetResourceDetail(t *testing.T) {
+	vm := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "resources.stuttgart-things.com/v1alpha1",
+			"kind":       "HarvesterVM",
+			"metadata":   map[string]any{"name": "detail-vm", "namespace": "team-x"},
+			"status": map[string]any{
+				"conditions": []any{map[string]any{"type": "Ready", "status": "True"}},
+				"vm":         map[string]any{"name": "the-vm"},
+			},
+		},
+	}
+	vm.SetGroupVersionKind(schema.GroupVersionKind{
+		Group: "resources.stuttgart-things.com", Version: "v1alpha1", Kind: "HarvesterVM",
+	})
+	s := newTestServer(t, vm)
+
+	t.Run("found, served from cache", func(t *testing.T) {
+		resp, err := s.GetResourceDetail(context.Background(), &resourceservice.ResourceDetailRequest{
+			Kind: "HarvesterVM", Name: "detail-vm", Namespace: "team-x",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.Name != "detail-vm" || !resp.Ready {
+			t.Errorf("unexpected detail: %+v", resp)
+		}
+		if !strings.Contains(resp.ConnectionDetails, "the-vm") {
+			t.Errorf("expected connection details to contain 'the-vm', got %q", resp.ConnectionDetails)
+		}
+	})
+
+	t.Run("missing resource returns NotFound", func(t *testing.T) {
+		_, err := s.GetResourceDetail(context.Background(), &resourceservice.ResourceDetailRequest{
+			Kind: "HarvesterVM", Name: "nope", Namespace: "team-x",
+		})
+		if st, _ := status.FromError(err); st.Code() != codes.NotFound {
+			t.Errorf("expected NotFound, got %v", st.Code())
+		}
+	})
+
+	t.Run("unsupported kind returns InvalidArgument", func(t *testing.T) {
+		_, err := s.GetResourceDetail(context.Background(), &resourceservice.ResourceDetailRequest{
+			Kind: "Nonexistent", Name: "x", Namespace: "y",
+		})
+		if st, _ := status.FromError(err); st.Code() != codes.InvalidArgument {
+			t.Errorf("expected InvalidArgument, got %v", st.Code())
+		}
+	})
+}
+
 func TestGetResourceStatus(t *testing.T) {
 	tests := []struct {
-		name       string
-		obj        map[string]any
-		wantMsg    string
-		wantReady  bool
+		name      string
+		obj       map[string]any
+		wantMsg   string
+		wantReady bool
 	}{
 		{
 			name:      "ready condition",

--- a/web_test.go
+++ b/web_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestWebIndex(t *testing.T) {
-	srv := newTestServer()
+	srv := newTestServer(t)
 	webSrv, err := newWebServer(srv)
 	if err != nil {
 		t.Fatalf("failed to create web server: %v", err)
@@ -66,7 +66,7 @@ func TestWebResources(t *testing.T) {
 		Group: "resources.stuttgart-things.com", Version: "v1alpha1", Kind: "HarvesterVM",
 	})
 
-	srv := newTestServer(obj)
+	srv := newTestServer(t, obj)
 	webSrv, err := newWebServer(srv)
 	if err != nil {
 		t.Fatalf("failed to create web server: %v", err)
@@ -92,7 +92,7 @@ func TestWebResources(t *testing.T) {
 }
 
 func TestWebResourcesEmpty(t *testing.T) {
-	srv := newTestServer()
+	srv := newTestServer(t)
 	webSrv, err := newWebServer(srv)
 	if err != nil {
 		t.Fatalf("failed to create web server: %v", err)
@@ -111,7 +111,7 @@ func TestWebResourcesEmpty(t *testing.T) {
 }
 
 func TestWebHealth(t *testing.T) {
-	srv := newTestServer()
+	srv := newTestServer(t)
 	webSrv, err := newWebServer(srv)
 	if err != nil {
 		t.Fatalf("failed to create web server: %v", err)
@@ -130,7 +130,7 @@ func TestWebHealth(t *testing.T) {
 }
 
 func TestWebNotFound(t *testing.T) {
-	srv := newTestServer()
+	srv := newTestServer(t)
 	webSrv, err := newWebServer(srv)
 	if err != nil {
 		t.Fatalf("failed to create web server: %v", err)
@@ -164,7 +164,7 @@ func TestWebResourcesNamespaceFilter(t *testing.T) {
 		return obj
 	}
 
-	srv := newTestServer(mkVM("vm-a", "team-a"), mkVM("vm-b", "team-b"), mkVM("vm-c", "team-a"))
+	srv := newTestServer(t, mkVM("vm-a", "team-a"), mkVM("vm-b", "team-b"), mkVM("vm-c", "team-a"))
 	webSrv, err := newWebServer(srv)
 	if err != nil {
 		t.Fatalf("failed to create web server: %v", err)
@@ -235,7 +235,7 @@ func TestWebResourcesNamespaceFilter(t *testing.T) {
 		clusterObj.SetGroupVersionKind(schema.GroupVersionKind{
 			Group: "resources.stuttgart-things.com", Version: "v1alpha1", Kind: "HarvesterVM",
 		})
-		srv2 := newTestServer(mkVM("vm-a", "team-a"), clusterObj)
+		srv2 := newTestServer(t, mkVM("vm-a", "team-a"), clusterObj)
 		webSrv2, _ := newWebServer(srv2)
 
 		req := httptest.NewRequest("GET", "/resources?kind=HarvesterVM&namespace=team-a", nil)


### PR DESCRIPTION
## Summary

`GetResources` / `GetResourceDetail` issued a **live `List`/`Get` against the API server on every call** — once per configured kind, for every gRPC request *and* every 5s dashboard poll. This replaces that with dynamic informers: one watch per kind, shared by all callers.

This is **part 1 of #76** — the informer cache that the `WatchResources` streaming RPC will build on. #76 stays open for that follow-up.

## Changes

- **`startInformers()`** (`main.go`) — probes each configured kind at boot, attaches a `dynamicinformer` for the ones the cluster serves, and skips the rest with a warning (preserves the old tolerance for kinds whose CRD is absent / API version retired). Blocks — bounded at 30s — on cache sync before the gRPC/HTTP servers start serving, so reads hit a warm cache. Informers stop via `stopCh` on shutdown.
- **`GetResources` / `GetResourceDetail`** now read from the informer **listers** — no per-request API call. Results are sorted by `(kind, namespace, name)` so the dashboard rows no longer shuffle between polls.
- API-server load drops from `O(kinds × callers × poll-rate)` to `O(kinds)`.
- **Tests** — `main_test.go` helpers reworked to drive the real `startInformers()` against a fake dynamic client (tests exercise the actual informer-cache path); added `TestGetResourceDetail`.

## Verification

- `go build`, `go vet`, `gofmt` clean.
- 34 tests pass under `-race`, including the reworked informer-path tests.
- Smoke-tested against the live homerun2-dev cluster: a bogus kind probed and skipped, 4 real kinds synced in ~100ms, `GetResources` returned 16 cached resources, `GetResourceDetail` returned a cached Certificate — no per-request API calls.

## Notes

- Behaviour change: `GetResourceDetail` with an empty namespace now does a cluster-scoped cache lookup instead of defaulting to `default` — correct for cluster-scoped kinds.
- Follow-up #76b: the `WatchResources` server-streaming RPC on top of this cache, which also lets the dashboard drop polling (removing the root cause of #75).

Part of #76.

🤖 Generated with [Claude Code](https://claude.com/claude-code)