### PR TITLE
fix(cmd): machinery-client list shows all resources by default

### DIFF
--- a/cmd/machinery-client/README.md
+++ b/cmd/machinery-client/README.md
@@ -50,7 +50,7 @@ Connection flags accepted on **every** subcommand:
 ```bash
 kubectl -n machinery port-forward svc/machinery 50051:50051 &
 
-machinery-client list  --kind=VsphereVMAnsible --count=10
+machinery-client list  --kind=VsphereVMAnsible          # all of them; --count=N to cap
 machinery-client get   --kind=VsphereVMAnsible --name=demo-vm --namespace=demo
 machinery-client watch --kind='*'
 machinery-client health
@@ -63,21 +63,39 @@ or `export MACHINERY_AUTH_TOKEN=…`.
 
 Once the [GRPCRoute is applied](../../kcl/grpcroute.k), machinery is
 addressable at the hostname the gateway listener exposes — e.g.
-`machinery.example.com:443` for a TLS listener.
+`machinery-grpc.example.com:443` for a TLS listener. Set the connection
+once via the environment, then every command is a one-liner:
 
 ```bash
-export MACHINERY_SERVER=machinery.example.com:443
-export MACHINERY_AUTH_TOKEN=$(kubectl -n machinery get secret machinery-auth -o jsonpath='{.data.token}' | base64 -d)
+export MACHINERY_SERVER=machinery-grpc.example.com:443
+export MACHINERY_INSECURE=false          # TLS, not plaintext, on :443
+export MACHINERY_TLS_SKIP_VERIFY=true    # gateway cert is from an internal CA
+export MACHINERY_AUTH_TOKEN=<bearer-token>
 
-machinery-client list  --insecure=false --kind='*' --count=20
-machinery-client watch --insecure=false --kind='*'
+machinery-client list  --kind='*'
+machinery-client get   --kind=Certificate --name=cluster-ca --namespace=cert-manager
+machinery-client watch --kind='*'
+machinery-client health
 ```
 
-Off-cluster gRPC over a TLS `:443` listener needs HTTP/2 ALPN on the
-Gateway — see [`kcl/README.md`](../../kcl/README.md). Use
-`--ca-cert=/path/to/ca.pem` for a private CA, or `--tls-skip-verify`
-for a quick smoke test. The bearer token is sent over TLS only by
-default; pass `--insecure` to also send it on a plaintext LAN dial.
+Every connection flag has a `MACHINERY_*` env var (see the table above),
+so a session like the one above needs no repeated flags. Concretely,
+against a preview env:
+
+```bash
+export MACHINERY_SERVER=machinery-pr-123-grpc.homerun2-dev.sthings-vsphere.labul.sva.de:443
+export MACHINERY_INSECURE=false
+export MACHINERY_TLS_SKIP_VERIFY=true
+export MACHINERY_AUTH_TOKEN=machinery-preview-grpc-token
+machinery-client list --kind='*'
+```
+
+Prefer verifying the chain: drop `MACHINERY_TLS_SKIP_VERIFY` and set
+`MACHINERY_CA_CERT=/path/to/ca.pem` with the gateway's CA bundle.
+Off-cluster gRPC over a TLS `:443` listener also needs HTTP/2 ALPN on
+the Gateway — see [`kcl/README.md`](../../kcl/README.md). The bearer
+token is sent over TLS only by default; set `MACHINERY_INSECURE=true`
+to also send it on a plaintext LAN dial.
 
 ### `watch`
 

--- a/cmd/machinery-client/main.go
+++ b/cmd/machinery-client/main.go
@@ -124,7 +124,7 @@ func runList(args []string) int {
 	var c commonFlags
 	registerCommon(fs, &c)
 	kind := fs.String("kind", "*", "kind to fetch (* for every configured kind)")
-	count := fs.Int("count", 5, "max resources to return (-1 = all)")
+	count := fs.Int("count", -1, "max resources to return (-1 = all)")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}

--- a/main.go
+++ b/main.go
@@ -320,22 +320,17 @@ func (s *server) GetResources(ctx context.Context, req *resourceservice.Resource
 		}
 		rk := s.config.Resources[kind]
 		for _, obj := range objs {
-			if req.Count == 0 {
-				break
-			}
 			item, ok := obj.(*unstructured.Unstructured)
 			if !ok {
 				continue
 			}
 			allResources = append(allResources, toResourceStatus(item, kind, rk))
-			if req.Count > 0 {
-				req.Count--
-			}
 		}
 	}
 
 	// Informer stores are unordered; sort for a stable response so the
-	// dashboard rows don't shuffle between polls.
+	// dashboard rows don't shuffle between polls — and so a count limit
+	// returns a predictable top-N, not an arbitrary subset.
 	sort.Slice(allResources, func(i, j int) bool {
 		a, b := allResources[i], allResources[j]
 		if a.Kind != b.Kind {
@@ -346,6 +341,12 @@ func (s *server) GetResources(ctx context.Context, req *resourceservice.Resource
 		}
 		return a.Name < b.Name
 	})
+
+	// Cap to req.Count after sorting (count<0 means "all"). Applying it
+	// here, not during iteration, keeps the limited set deterministic.
+	if req.Count >= 0 && len(allResources) > int(req.Count) {
+		allResources = allResources[:int(req.Count)]
+	}
 
 	slog.Info("resources fetched", "count", len(allResources))
 	return &resourceservice.ResourceListResponse{Resources: allResources}, nil

--- a/main_test.go
+++ b/main_test.go
@@ -280,7 +280,14 @@ func TestGetResources_CountLimit(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if len(resp.Resources) != 2 {
-		t.Errorf("expected 2 resources (count limit), got %d", len(resp.Resources))
+		t.Fatalf("expected 2 resources (count limit), got %d", len(resp.Resources))
+	}
+	// The cap is applied after the sort, so it is a deterministic
+	// top-N — the first two by (kind, namespace, name), not an
+	// arbitrary subset of the informer store's iteration order.
+	if resp.Resources[0].Name != "vm-0" || resp.Resources[1].Name != "vm-1" {
+		t.Errorf("expected the sorted top-2 [vm-0 vm-1], got [%s %s]",
+			resp.Resources[0].Name, resp.Resources[1].Name)
 	}
 }
 


### PR DESCRIPTION
## Summary

`machinery-client list` showed fewer resources than the dashboard — surfaced while testing against a preview env (18 in the GUI, 5 from the CLI). Two related causes:

1. **`machinery-client list` defaulted to `--count=5`** — a leftover from when this was example code. It silently showed 5 of N with no "showing 5 of N" hint, while the dashboard applies no limit.
2. **`--count=N` returned an *arbitrary* N.** `GetResources` applied the cap while iterating kinds (in non-deterministic informer/map order) and sorted only afterward — so `--count=5` was 5 random rows, then sorted for display.

## Changes

- **`cmd/machinery-client`** — `list` defaults `--count` to `-1` (all), matching the dashboard and `kubectl get`. The flag still caps the result when you want it to.
- **`main.go` (`GetResources`)** — collect all matching resources, sort by `(kind, namespace, name)`, **then** truncate to `count`. `--count=N` is now a deterministic top-N. (`count` is unbounded-cheap here — a handful of kinds, hundreds of resources at most.)

## Verification

- `go build`, `go vet ./...`, `gofmt`, `go test -race ./...` — all pass. `TestGetResources_CountLimit` now also asserts the cap returns the sorted top-2 (`vm-0`, `vm-1`), not an arbitrary pair.
- Smoke-tested against the live `machinery-pr-81` preview env: `machinery-client list` now returns all **18** resources (matching the dashboard); `--count=3` still caps to 3.

Follow-up flagged during #75 / #77 testing — not tied to an issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)