### PR TITLE
fix(configs): correct AnsibleRun field paths in platforms.json example

### DIFF
--- a/examples/configs/platforms.json
+++ b/examples/configs/platforms.json
@@ -41,14 +41,20 @@
       "group": "resources.stuttgart-things.com",
       "version": "v1alpha1",
       "resource": "ansibleruns",
-      "connectionField": "status.lastRunTime",
+      "connectionField": "status.pipelineRunName",
       "statusFields": [
-        "status.phase",
-        "status.observedGeneration"
+        "status.succeeded",
+        "status.installed",
+        "status.reason"
       ],
       "infoFields": [
-        { "label": "Playbook", "path": "spec.playbook" },
-        { "label": "Inventory","path": "spec.inventory" }
+        { "label": "Playbooks",  "path": "spec.ansiblePlaybooks" },
+        { "label": "Target",     "path": "spec.ansibleTargetHost" },
+        { "label": "Namespace",  "path": "spec.namespace" },
+        { "label": "GitRepo",    "path": "spec.gitRepoUrl" },
+        { "label": "Message",    "path": "status.message" },
+        { "label": "Started",    "path": "status.startTime" },
+        { "label": "Completed",  "path": "status.completionTime" }
       ]
     }
   }


### PR DESCRIPTION
## What

The `AnsibleRun` entry in `examples/configs/platforms.json` pointed at fields the XRD does not define (`status.phase`, `status.observedGeneration`, `status.lastRunTime`, `spec.playbook`, `spec.inventory`) — the dashboard rendered them empty.

## Fix

Use the real `AnsibleRun` (`resources.stuttgart-things.com/v1alpha1`) fields, taken from the live XRD:

- connection: `status.pipelineRunName`
- status: `succeeded`, `installed`, `reason`
- info: playbooks / target / namespace / gitRepo + message / started / completed

Matches the `kinds` catalog entry added in [stuttgart-things/argocd#214](https://github.com/stuttgart-things/argocd/pull/214).

🤖 Generated with [Claude Code](https://claude.com/claude-code)