### PR TITLE
fix: rename Go module path to github.com/stuttgart-things/machinery

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -8,7 +8,7 @@ import (
 	"log"
 	"os"
 
-	resourceservice "github.com/stuttgart-things/maschinist/resourceservice"
+	resourceservice "github.com/stuttgart-things/machinery/resourceservice"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"

--- a/cmd/machinery-client/main.go
+++ b/cmd/machinery-client/main.go
@@ -20,7 +20,7 @@ import (
 	"text/tabwriter"
 	"time"
 
-	resourceservice "github.com/stuttgart-things/maschinist/resourceservice"
+	resourceservice "github.com/stuttgart-things/machinery/resourceservice"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/stuttgart-things/maschinist
+module github.com/stuttgart-things/machinery
 
 go 1.26.0
 

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 	"syscall"
 	"time"
 
-	resourceservice "github.com/stuttgart-things/maschinist/resourceservice"
+	resourceservice "github.com/stuttgart-things/machinery/resourceservice"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"

--- a/main_test.go
+++ b/main_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	resourceservice "github.com/stuttgart-things/maschinist/resourceservice"
+	resourceservice "github.com/stuttgart-things/machinery/resourceservice"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"

--- a/resourceservice/resource_service.proto
+++ b/resourceservice/resource_service.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package resourceservice;
 
-option go_package = "github.com/stuttgart-things/maschinist";
+option go_package = "github.com/stuttgart-things/machinery/resourceservice;maschinist";
 
 // Define the ResourceStatus struct
 message ResourceStatus {

--- a/tests/e2e/grpc_e2e_test.go
+++ b/tests/e2e/grpc_e2e_test.go
@@ -16,7 +16,7 @@ import (
 	"testing"
 	"time"
 
-	resourceservice "github.com/stuttgart-things/maschinist/resourceservice"
+	resourceservice "github.com/stuttgart-things/machinery/resourceservice"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 )

--- a/web.go
+++ b/web.go
@@ -10,7 +10,7 @@ import (
 	"sort"
 	"strings"
 
-	resourceservice "github.com/stuttgart-things/maschinist/resourceservice"
+	resourceservice "github.com/stuttgart-things/machinery/resourceservice"
 )
 
 //go:embed web/templates/*.html


### PR DESCRIPTION
## What

Renames the Go module path from `github.com/stuttgart-things/maschinist` to `github.com/stuttgart-things/machinery` so it matches the repository and becomes go-gettable by external consumers (e.g. the new `machinery-catalog-publisher`, which imports `resourceservice`).

## Changes

- `go.mod` module path
- all internal import paths (`main.go`, `web.go`, `client/`, `cmd/machinery-client`, tests)
- proto `go_package` → `.../machinery/resourceservice;maschinist` so a future regen keeps the existing package name (`maschinist`) and a correct import path

The generated package name `maschinist` is intentionally left unchanged — renaming it is a separate cleanup. No behavior change.

## Release note

This is a `fix:` (patch) on purpose: it must **not** trigger a major bump, since Go would then require a `/v2` path suffix. The old module path was never resolvable, so there are no external consumers to break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)